### PR TITLE
Add a base OracleAdapter and a way to prove ancestral blocks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.formatOnSave": true,
-  "liveServer.settings.root": "/coverage"
+  "liveServer.settings.root": "/coverage",
+  "cSpell.words": ["hexlify"]
 }

--- a/contracts/adapters/AMB/AMBAdapter.sol
+++ b/contracts/adapters/AMB/AMBAdapter.sol
@@ -2,13 +2,12 @@
 pragma solidity ^0.8.17;
 
 import "./IAMB.sol";
-import "../IOracleAdapter.sol";
+import "../OracleAdapter.sol";
 
-contract AMBAdapter {
+contract AMBAdapter is OracleAdapter {
     IAMB public amb;
     address public headerReporter;
     bytes32 public chainId;
-    mapping(uint256 => bytes32) public headers;
 
     event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
 
@@ -52,18 +51,10 @@ contract AMBAdapter {
     }
 
     function _storeBlockHeader(uint256 blockNumber, bytes32 blockHeader) internal onlyValid {
-        bytes32 currentBlockHeader = headers[blockNumber];
+        bytes32 currentBlockHeader = headers[uint256(chainId)][blockNumber];
         if (currentBlockHeader != blockHeader) {
-            headers[blockNumber] = blockHeader;
+            headers[uint256(chainId)][blockNumber] = blockHeader;
             emit HeaderStored(blockNumber, blockHeader);
         }
-    }
-
-    /// @dev Returns the block header for a given block, as reported by the AMB.
-    /// @param blockNumber Identifier for the block to query.
-    /// @return blockHeader Bytes32 block header reported by the oracle for the given block on the given chain.
-    /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
-    function getHeaderFromOracle(uint256, uint256 blockNumber) external view returns (bytes32 blockHeader) {
-        blockHeader = headers[blockNumber];
     }
 }

--- a/contracts/adapters/AMB/AMBAdapter.sol
+++ b/contracts/adapters/AMB/AMBAdapter.sol
@@ -9,8 +9,6 @@ contract AMBAdapter is OracleAdapter {
     address public headerReporter;
     bytes32 public chainId;
 
-    event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
-
     error ArrayLengthMissmatch(address emitter);
     error UnauthorizedAMB(address emitter, address sender);
     error UnauthorizedChainId(address emitter, bytes32 chainId);

--- a/contracts/adapters/Connext/ConnextAdapter.sol
+++ b/contracts/adapters/Connext/ConnextAdapter.sol
@@ -3,11 +3,10 @@ pragma solidity ^0.8.17;
 
 import "@connext/interfaces/core/IConnext.sol";
 import "@connext/interfaces/core/IXReceiver.sol";
-import "../IOracleAdapter.sol";
+import "../OracleAdapter.sol";
 
-contract ConnextAdapter is IXReceiver {
+contract ConnextAdapter is IXReceiver, OracleAdapter {
     bytes32 public headerReporter;
-    mapping(uint256 => mapping(uint256 => bytes32)) public headers;
 
     event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
 
@@ -77,13 +76,5 @@ contract ConnextAdapter is IXReceiver {
             headers[uint256(domainToChainId[_origin])][blockNumber] = newBlockHeader;
             emit HeaderStored(blockNumber, newBlockHeader);
         }
-    }
-
-    /// @dev Returns the block header for a given block, as reported by the Wormhole.
-    /// @param blockNumber Identifier for the block to query.
-    /// @return blockHeader Bytes32 block header reported by the oracle for the given block on the given chain.
-    /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
-    function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader) {
-        blockHeader = headers[chainId][blockNumber];
     }
 }

--- a/contracts/adapters/Connext/ConnextAdapter.sol
+++ b/contracts/adapters/Connext/ConnextAdapter.sol
@@ -8,8 +8,6 @@ import "../OracleAdapter.sol";
 contract ConnextAdapter is IXReceiver, OracleAdapter {
     bytes32 public headerReporter;
 
-    event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
-
     error InvalidInputs();
     error InvalidSource(address _originSender, uint32 _origin);
 

--- a/contracts/adapters/IOracleAdapter.sol
+++ b/contracts/adapters/IOracleAdapter.sol
@@ -9,5 +9,5 @@ interface IOracleAdapter {
     /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
     function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader);
 
-    event HeaderNewStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
+    event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
 }

--- a/contracts/adapters/IOracleAdapter.sol
+++ b/contracts/adapters/IOracleAdapter.sol
@@ -10,4 +10,8 @@ interface IOracleAdapter {
     function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader);
 
     event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
+
+    error InvalidBlockHeaderProofLength(uint256 length);
+    error InvalidBlockHeaderProofRLP();
+    error InvalidBlockHeaderProof(uint256 blockNumber, bytes32 blockHeader);
 }

--- a/contracts/adapters/IOracleAdapter.sol
+++ b/contracts/adapters/IOracleAdapter.sol
@@ -8,4 +8,6 @@ interface IOracleAdapter {
     /// @return blockHeader Block header reported by the oracle for the given block on the given chain.
     /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
     function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader);
+
+    event HeaderNewStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
 }

--- a/contracts/adapters/OracleAdapter.sol
+++ b/contracts/adapters/OracleAdapter.sol
@@ -3,27 +3,35 @@ pragma solidity ^0.8.17;
 
 import "./IOracleAdapter.sol";
 
-import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import "solidity-rlp/contracts/RLPReader.sol";
 
 contract OracleAdapter is IOracleAdapter {
     mapping(uint256 => mapping(uint256 => bytes32)) public headers;
 
-    /// @dev Returns the block header for a given block, as reported by the AMB.
-    /// @param chainId Identifier for the chain to query.
-    /// @param blockNumber Identifier for the block to query.
-    /// @return blockHeader Bytes32 block header reported by the oracle for the given block on the given chain.
-    /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
+    using RLPReader for RLPReader.RLPItem;
+
     function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader) {
         blockHeader = headers[chainId][blockNumber];
     }
 
-    function proveUnreportedHeader(
-        uint256 chainId,
-        uint256 rootBlockNumber,
-        bytes32 leafBlockHeader,
-        bytes32[] memory proof
-    ) external view returns (bool) {
-        bytes32 rootBlockHeader = headers[chainId][rootBlockNumber];
-        return MerkleProof.verify(proof, rootBlockHeader, leafBlockHeader);
+    function proveHeaders(uint256 chainId, bytes32[] memory blockHeaders, bytes[] memory blockHeaderContents) external {
+        if (blockHeaders.length != blockHeaderContents.length) revert("Array Mismatch");
+
+        for (uint256 i = 0; i < blockHeaders.length; i++) {
+            RLPReader.RLPItem[] memory blockHeaderContent = RLPReader.toRlpItem(blockHeaderContents[i]).toList();
+
+            bytes32 blockHeader = blockHeaders[i];
+
+            if (blockHeader != keccak256(blockHeaderContents[i])) revert("Header Mismatch");
+
+            bytes32 blockParent = bytes32(blockHeaderContent[0].toUint());
+            uint256 blockNumber = uint256(blockHeaderContent[8].toUint());
+
+            if (headers[chainId][blockNumber] != blockHeader) revert("Proof doesn't match up");
+
+            headers[chainId][blockNumber - 1] = blockParent;
+
+            emit HeaderNewStored(blockNumber, blockHeader);
+        }
     }
 }

--- a/contracts/adapters/OracleAdapter.sol
+++ b/contracts/adapters/OracleAdapter.sol
@@ -31,7 +31,7 @@ contract OracleAdapter is IOracleAdapter {
 
             headers[chainId][blockNumber - 1] = blockParent;
 
-            emit HeaderNewStored(blockNumber, blockHeader);
+            emit HeaderStored(blockNumber - 1, blockParent);
         }
     }
 }

--- a/contracts/adapters/OracleAdapter.sol
+++ b/contracts/adapters/OracleAdapter.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import "./IOracleAdapter.sol";
+
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+contract OracleAdapter is IOracleAdapter {
+    mapping(uint256 => mapping(uint256 => bytes32)) public headers;
+
+    /// @dev Returns the block header for a given block, as reported by the AMB.
+    /// @param chainId Identifier for the chain to query.
+    /// @param blockNumber Identifier for the block to query.
+    /// @return blockHeader Bytes32 block header reported by the oracle for the given block on the given chain.
+    /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
+    function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader) {
+        blockHeader = headers[chainId][blockNumber];
+    }
+
+    function proveUnreportedHeader(
+        uint256 chainId,
+        uint256 rootBlockNumber,
+        bytes32 leafBlockHeader,
+        bytes32[] memory proof
+    ) external view returns (bool) {
+        bytes32 rootBlockHeader = headers[chainId][rootBlockNumber];
+        return MerkleProof.verify(proof, rootBlockHeader, leafBlockHeader);
+    }
+}

--- a/contracts/adapters/Wormhole/WormholeAdapter.sol
+++ b/contracts/adapters/Wormhole/WormholeAdapter.sol
@@ -8,8 +8,6 @@ contract WormholeAdapter is OracleAdapter {
     IWormhole public wormhole;
     bytes32 public headerReporter;
 
-    event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
-
     error InvalidMessage(address emitter, VM vm, string reason);
     error InvalidChainId(address emitter, uint16 chainId);
     error InvalidReporter(address emitter, bytes32 reporter);

--- a/contracts/adapters/Wormhole/WormholeAdapter.sol
+++ b/contracts/adapters/Wormhole/WormholeAdapter.sol
@@ -2,12 +2,11 @@
 pragma solidity ^0.8.17;
 
 import "./IWormhole.sol";
-import "../IOracleAdapter.sol";
+import "../OracleAdapter.sol";
 
-contract WormholeAdapter {
+contract WormholeAdapter is OracleAdapter {
     IWormhole public wormhole;
     bytes32 public headerReporter;
-    mapping(uint256 => mapping(uint256 => bytes32)) public headers;
 
     event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
 
@@ -36,13 +35,5 @@ contract WormholeAdapter {
             headers[uint256(chainId)][blockNumber] = newBlockHeader;
             emit HeaderStored(blockNumber, newBlockHeader);
         }
-    }
-
-    /// @dev Returns the block header for a given block, as reported by the Wormhole.
-    /// @param blockNumber Identifier for the block to query.
-    /// @return blockHeader Bytes32 block header reported by the oracle for the given block on the given chain.
-    /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
-    function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader) {
-        blockHeader = headers[chainId][blockNumber];
     }
 }

--- a/contracts/test/MockOracleAdapter.sol
+++ b/contracts/test/MockOracleAdapter.sol
@@ -1,21 +1,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import "../adapters/IOracleAdapter.sol";
+import "../adapters/OracleAdapter.sol";
 
-contract MockOracleAdapter is IOracleAdapter {
-    mapping(uint256 => mapping(uint256 => bytes32)) public blockHeaders;
-
+contract MockOracleAdapter is OracleAdapter {
     error LengthMismatch(address emitter);
-
-    function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader) {
-        blockHeader = blockHeaders[chainId][blockNumber];
-    }
 
     function setBlockHeaders(uint256 chainId, uint256[] memory blockNumbers, bytes32[] memory _blockHeaders) external {
         if (blockNumbers.length != _blockHeaders.length) revert LengthMismatch(address(this));
         for (uint i = 0; i < blockNumbers.length; i++) {
-            blockHeaders[chainId][blockNumbers[i]] = _blockHeaders[i];
+            headers[chainId][blockNumbers[i]] = _blockHeaders[i];
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
   },
   "dependencies": {
     "@connext/interfaces": "^2.0.0",
-    "@openzeppelin/contracts-upgradeable": "^4.8.1"
+    "@openzeppelin/contracts-upgradeable": "^4.8.1",
+    "merkletreejs": "^0.3.9",
+    "solidity-rlp": "^2.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
   "dependencies": {
     "@connext/interfaces": "^2.0.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.1",
-    "merkletreejs": "^0.3.9",
     "solidity-rlp": "^2.0.7"
   }
 }

--- a/test/adapters/02_OracleAdapter.spec.ts
+++ b/test/adapters/02_OracleAdapter.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from "chai"
+import { hexlify } from "ethers/lib/utils"
+import { ethers, network } from "hardhat"
+
+const CHAIN_ID = 1
+
+const mine = async (n: number) => await Promise.all([...Array(n)].map(() => network.provider.send("evm_mine")))
+
+const emptyHexlify = (value: string) => {
+  const hex = ethers.utils.hexlify(value, { hexPad: "left" })
+  return hex === "0x00" ? "0x" : hex
+}
+
+const blockRLP = (block: any) => {
+  const values = [
+    block.parentHash,
+    block.sha3Uncles,
+    block.miner,
+    block.stateRoot,
+    block.transactionsRoot,
+    block.receiptsRoot,
+    block.logsBloom,
+    block.difficulty,
+    block.number,
+    block.gasLimit,
+    block.gasUsed,
+    block.timestamp,
+    block.extraData,
+    block.mixHash,
+    block.nonce,
+    block.baseFeePerGas,
+  ]
+  return ethers.utils.RLP.encode(values.map(emptyHexlify))
+}
+
+const setup = async () => {
+  await network.provider.request({ method: "hardhat_reset", params: [] })
+  const [wallet] = await ethers.getSigners()
+  const OracleAdapter = await ethers.getContractFactory("MockOracleAdapter")
+  const oracleAdapter = await OracleAdapter.deploy()
+  await mine(120)
+  const reportedBlockNumbers = [100, 110]
+  const reportedBlockHeaders = await Promise.all(
+    reportedBlockNumbers.map(async (blockNumber) => (await ethers.provider.getBlock(blockNumber)).hash),
+  )
+  await oracleAdapter.setBlockHeaders(CHAIN_ID, reportedBlockNumbers, reportedBlockHeaders)
+  return {
+    wallet,
+    oracleAdapter,
+    reportedBlockNumbers,
+    reportedBlockHeaders,
+  }
+}
+
+const getBlock = async (blockNumber: number) => {
+  return await ethers.provider.send("eth_getBlockByNumber", [hexlify(blockNumber), false])
+}
+
+describe.only("HeaderStorage", function () {
+  describe("Deploy", function () {
+    it("Successfully deploys contract", async function () {
+      const { oracleAdapter } = await setup()
+      expect(await oracleAdapter.deployed())
+    })
+  })
+
+  describe("proveHeaders()", function () {
+    it("Verifies a unreported block header", async function () {
+      const { oracleAdapter } = await setup()
+
+      const bockNumbers = [110, 109, 108, 107]
+      const blocks = await Promise.all(bockNumbers.map(async (blockNumber) => await getBlock(blockNumber)))
+      const headerContents = blocks.map((block) => blockRLP(block))
+      const headers = blocks.map((block) => block.hash)
+
+      await oracleAdapter.proveHeaders(CHAIN_ID, headers, headerContents)
+    })
+  })
+})

--- a/test/adapters/02_OracleAdapter.spec.ts
+++ b/test/adapters/02_OracleAdapter.spec.ts
@@ -1,9 +1,10 @@
 import { expect } from "chai"
-import { hexlify } from "ethers/lib/utils"
+import { RLP, hexlify } from "ethers/lib/utils"
 import { ethers, network } from "hardhat"
 
 const CHAIN_ID = 1
 
+// Use evm_mine instead of hardhat_mine because hardhat_mine doesn't provide valid blocks
 const mine = async (n: number) => await Promise.all([...Array(n)].map(() => network.provider.send("evm_mine")))
 
 const emptyHexlify = (value: string) => {
@@ -30,7 +31,15 @@ const blockRLP = (block: any) => {
     block.nonce,
     block.baseFeePerGas,
   ]
-  return ethers.utils.RLP.encode(values.map(emptyHexlify))
+  return RLP.encode(values.map(emptyHexlify))
+}
+
+const getBlock = async (blockNumber: number) => {
+  const block = await ethers.provider.send("eth_getBlockByNumber", [hexlify(blockNumber), false])
+  return {
+    ...block,
+    blockNumber,
+  }
 }
 
 const setup = async () => {
@@ -40,23 +49,26 @@ const setup = async () => {
   const oracleAdapter = await OracleAdapter.deploy()
   await mine(120)
   const reportedBlockNumbers = [100, 110]
-  const reportedBlockHeaders = await Promise.all(
-    reportedBlockNumbers.map(async (blockNumber) => (await ethers.provider.getBlock(blockNumber)).hash),
+  const unreportedBlockNumbers = [109, 108, 107]
+  const blocks = await Promise.all(
+    reportedBlockNumbers.concat(unreportedBlockNumbers).map(async (blockNumber) => await getBlock(blockNumber)),
   )
+  const reportedBlockHeaders = blocks
+    .filter((block) => reportedBlockNumbers.includes(block.blockNumber))
+    .map((block) => block.hash)
+
   await oracleAdapter.setBlockHeaders(CHAIN_ID, reportedBlockNumbers, reportedBlockHeaders)
   return {
     wallet,
     oracleAdapter,
     reportedBlockNumbers,
     reportedBlockHeaders,
+    unreportedBlockNumbers,
+    blocks,
   }
 }
 
-const getBlock = async (blockNumber: number) => {
-  return await ethers.provider.send("eth_getBlockByNumber", [hexlify(blockNumber), false])
-}
-
-describe.only("HeaderStorage", function () {
+describe("HeaderStorage", function () {
   describe("Deploy", function () {
     it("Successfully deploys contract", async function () {
       const { oracleAdapter } = await setup()
@@ -64,16 +76,63 @@ describe.only("HeaderStorage", function () {
     })
   })
 
-  describe("proveHeaders()", function () {
-    it("Verifies a unreported block header", async function () {
+  describe("proveAncestralHeaders()", function () {
+    it("Adds ancestral block headers of proven blocks", async function () {
+      const { oracleAdapter, blocks } = await setup()
+      const headerProofs = blocks.map((block) => blockRLP(block))
+
+      // All blocks should have been proven and their ancestral headers stored
+      for (const block of blocks) {
+        await expect(oracleAdapter.proveAncestralHeaders(CHAIN_ID, headerProofs))
+          .to.emit(oracleAdapter, "HeaderStored")
+          .withArgs(block.blockNumber - 1, block.parentHash)
+      }
+    })
+
+    it("Reverts if given unknown blocks", async function () {
+      const { oracleAdapter, blocks, unreportedBlockNumbers } = await setup()
+      const unreportedBlockNumber = unreportedBlockNumbers[0]
+      const unreportedBlock = blocks.find((block) => block.blockNumber === unreportedBlockNumber)
+      const headerProofs = [blockRLP(unreportedBlock)]
+
+      await expect(oracleAdapter.proveAncestralHeaders(CHAIN_ID, headerProofs))
+        .to.revertedWithCustomError(oracleAdapter, "InvalidBlockHeaderProof")
+        .withArgs(unreportedBlockNumber, unreportedBlock.hash)
+    })
+
+    it("Reverts if block proof is invalid RLP", async function () {
       const { oracleAdapter } = await setup()
+      const invalidRLP = ["0xa0000000"]
 
-      const bockNumbers = [110, 109, 108, 107]
-      const blocks = await Promise.all(bockNumbers.map(async (blockNumber) => await getBlock(blockNumber)))
-      const headerContents = blocks.map((block) => blockRLP(block))
-      const headers = blocks.map((block) => block.hash)
+      // Invalid block proof
+      await expect(oracleAdapter.proveAncestralHeaders(CHAIN_ID, invalidRLP)).to.revertedWithCustomError(
+        oracleAdapter,
+        "InvalidBlockHeaderProofRLP",
+      )
+    })
 
-      await oracleAdapter.proveHeaders(CHAIN_ID, headers, headerContents)
+    it("Reverts if block proof doesn't match valid block header lengths", async function () {
+      const { oracleAdapter, blocks } = await setup()
+      const blockHeaderProofContents = RLP.decode(blockRLP(blocks[0]))
+      const blockHeaderProofTooShortContents = blockHeaderProofContents.slice(0, 14)
+      const blockHeaderProofTooShort = RLP.encode(blockHeaderProofTooShortContents)
+
+      // Block proof RLP contains too few elements
+      await expect(oracleAdapter.proveAncestralHeaders(CHAIN_ID, [blockHeaderProofTooShort]))
+        .to.revertedWithCustomError(oracleAdapter, "InvalidBlockHeaderProofLength")
+        .withArgs(blockHeaderProofTooShortContents.length)
+
+      console.log(blockHeaderProofContents.length)
+      const blockHeaderProofTooLongContents = blockHeaderProofContents.concat([
+        oracleAdapter.address,
+        oracleAdapter.address,
+      ])
+      const blockHeaderProofTooLong = RLP.encode(blockHeaderProofTooLongContents)
+
+      // Block proof RLP contains too many elements
+      await expect(oracleAdapter.proveAncestralHeaders(CHAIN_ID, [blockHeaderProofTooLong]))
+        .to.revertedWithCustomError(oracleAdapter, "InvalidBlockHeaderProofLength")
+        .withArgs(blockHeaderProofTooLongContents.length)
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,7 +1002,6 @@ __metadata:
     husky: ^8.0.2
     lint-staged: ^13.0.4
     lodash: ^4.17.21
-    merkletreejs: ^0.3.9
     mocha: ^10.1.0
     pinst: ^3.0.0
     prettier: ^2.8.0
@@ -2781,13 +2780,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-reverse@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "buffer-reverse@npm:1.0.1"
-  checksum: e350872a89b17af0a7e1bd7a73239a535164f3f010b0800add44f2e52bd0511548dc5b96c20309effba969868c385023d2d02a0add6155f6a76da7b3073b77bd
-  languageName: node
-  linkType: hard
-
 "buffer-xor@npm:^1.0.3":
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
@@ -3596,13 +3588,6 @@ __metadata:
   version: 0.0.2
   resolution: "crypt@npm:0.0.2"
   checksum: baf4c7bbe05df656ec230018af8cf7dbe8c14b36b98726939cef008d473f6fe7a4fad906cfea4062c93af516f1550a3f43ceb4d6615329612c6511378ed9fe34
-  languageName: node
-  linkType: hard
-
-"crypto-js@npm:^3.1.9-1":
-  version: 3.3.0
-  resolution: "crypto-js@npm:3.3.0"
-  checksum: 193923143a4784b2f974366068d96fe8280168fd3fef2bfea9551a5c3e32096f5a8fa49ff4eeb5bd0b9716d325618d38cfbe6125e359a4ef488fbca93e600824
   languageName: node
   linkType: hard
 
@@ -6909,19 +6894,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merkletreejs@npm:^0.3.9":
-  version: 0.3.9
-  resolution: "merkletreejs@npm:0.3.9"
-  dependencies:
-    bignumber.js: ^9.0.1
-    buffer-reverse: ^1.0.1
-    crypto-js: ^3.1.9-1
-    treeify: ^1.1.0
-    web3-utils: ^1.3.4
-  checksum: a76ba14cb3e7ba342572b479956e8b159e498a101e79da796ee032ad4cb8d53bae1af38e8b70dfa64784e659b4a0bc9e75274517ab68788b1459bca8047f1f3f
-  languageName: node
-  linkType: hard
-
 "micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
@@ -9569,13 +9541,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"treeify@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "treeify@npm:1.1.0"
-  checksum: aa00dded220c1dd052573bd6fc2c52862f09870851a284f0d3650d72bf913ba9b4f6b824f4f1ab81899bae29375f4266b07fe47cbf82343a1efa13cc09ce87af
-  languageName: node
-  linkType: hard
-
 "trim-newlines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
@@ -10027,21 +9992,6 @@ __metadata:
   dependencies:
     defaults: ^1.0.3
   checksum: 814e9d1ddcc9798f7377ffa448a5a3892232b9275ebb30a41b529607691c0491de47cba426e917a4d08ded3ee7e9ba2f3fe32e62ee3cd9c7d3bafb7754bd553c
-  languageName: node
-  linkType: hard
-
-"web3-utils@npm:^1.3.4":
-  version: 1.8.2
-  resolution: "web3-utils@npm:1.8.2"
-  dependencies:
-    bn.js: ^5.2.1
-    ethereum-bloom-filters: ^1.0.6
-    ethereumjs-util: ^7.1.0
-    ethjs-unit: 0.1.6
-    number-to-bn: 1.7.0
-    randombytes: ^2.1.0
-    utf8: 3.0.0
-  checksum: a6cda086d7bde4939fc55be8f1dc5040b4cacd9205ac2ac07f37d14305214679e030af7814a3e97f6fabf2901e3452cd0dc8ce7c1cdd8bce4d0d4bae72c50ad9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,6 +1002,7 @@ __metadata:
     husky: ^8.0.2
     lint-staged: ^13.0.4
     lodash: ^4.17.21
+    merkletreejs: ^0.3.9
     mocha: ^10.1.0
     pinst: ^3.0.0
     prettier: ^2.8.0
@@ -1010,6 +1011,7 @@ __metadata:
     solhint: ^3.3.7
     solhint-plugin-prettier: ^0.0.5
     solidity-coverage: ^0.8.2
+    solidity-rlp: ^2.0.7
     ts-generator: ^0.1.1
     ts-node: ^10.9.1
     typechain: ^8.1.1
@@ -2779,6 +2781,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-reverse@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "buffer-reverse@npm:1.0.1"
+  checksum: e350872a89b17af0a7e1bd7a73239a535164f3f010b0800add44f2e52bd0511548dc5b96c20309effba969868c385023d2d02a0add6155f6a76da7b3073b77bd
+  languageName: node
+  linkType: hard
+
 "buffer-xor@npm:^1.0.3":
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
@@ -3587,6 +3596,13 @@ __metadata:
   version: 0.0.2
   resolution: "crypt@npm:0.0.2"
   checksum: baf4c7bbe05df656ec230018af8cf7dbe8c14b36b98726939cef008d473f6fe7a4fad906cfea4062c93af516f1550a3f43ceb4d6615329612c6511378ed9fe34
+  languageName: node
+  linkType: hard
+
+"crypto-js@npm:^3.1.9-1":
+  version: 3.3.0
+  resolution: "crypto-js@npm:3.3.0"
+  checksum: 193923143a4784b2f974366068d96fe8280168fd3fef2bfea9551a5c3e32096f5a8fa49ff4eeb5bd0b9716d325618d38cfbe6125e359a4ef488fbca93e600824
   languageName: node
   linkType: hard
 
@@ -6893,6 +6909,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"merkletreejs@npm:^0.3.9":
+  version: 0.3.9
+  resolution: "merkletreejs@npm:0.3.9"
+  dependencies:
+    bignumber.js: ^9.0.1
+    buffer-reverse: ^1.0.1
+    crypto-js: ^3.1.9-1
+    treeify: ^1.1.0
+    web3-utils: ^1.3.4
+  checksum: a76ba14cb3e7ba342572b479956e8b159e498a101e79da796ee032ad4cb8d53bae1af38e8b70dfa64784e659b4a0bc9e75274517ab68788b1459bca8047f1f3f
+  languageName: node
+  linkType: hard
+
 "micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
@@ -8990,6 +9019,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"solidity-rlp@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "solidity-rlp@npm:2.0.7"
+  checksum: 05df8300ed3f1a99eab45177f7dfe95310e0eb1bce7808379285b4a8c5b9f1bb17f3a7ce778a9416889f3b7ecaeb2d365450507f89ca7f4c99e02ac90166e60f
+  languageName: node
+  linkType: hard
+
 "source-map-support@npm:^0.5.13, source-map-support@npm:^0.5.16":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
@@ -9533,6 +9569,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"treeify@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "treeify@npm:1.1.0"
+  checksum: aa00dded220c1dd052573bd6fc2c52862f09870851a284f0d3650d72bf913ba9b4f6b824f4f1ab81899bae29375f4266b07fe47cbf82343a1efa13cc09ce87af
+  languageName: node
+  linkType: hard
+
 "trim-newlines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
@@ -9984,6 +10027,21 @@ __metadata:
   dependencies:
     defaults: ^1.0.3
   checksum: 814e9d1ddcc9798f7377ffa448a5a3892232b9275ebb30a41b529607691c0491de47cba426e917a4d08ded3ee7e9ba2f3fe32e62ee3cd9c7d3bafb7754bd553c
+  languageName: node
+  linkType: hard
+
+"web3-utils@npm:^1.3.4":
+  version: 1.8.2
+  resolution: "web3-utils@npm:1.8.2"
+  dependencies:
+    bn.js: ^5.2.1
+    ethereum-bloom-filters: ^1.0.6
+    ethereumjs-util: ^7.1.0
+    ethjs-unit: 0.1.6
+    number-to-bn: 1.7.0
+    randombytes: ^2.1.0
+    utf8: 3.0.0
+  checksum: a6cda086d7bde4939fc55be8f1dc5040b4cacd9205ac2ac07f37d14305214679e030af7814a3e97f6fabf2901e3452cd0dc8ce7c1cdd8bce4d0d4bae72c50ad9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Each adapter now uses the `OracleAdapter` as a base.

The OracleAdapter includes the `proveAncestralHeaders(uint256 chainId, bytes[] memory blockHeaderProofs)` function which makes it possible to add block headers without having the reporter contract having to report them.

Say we have block x reported to the oracle. A user can then prove the ancestor of that block by sending it the RLP encoded block header. This would add the `parentHash` to the list of stored headers.

`proveAncestralHeaders` accepts an array of RLP encoded block headers. It will process the block headers in order so it's important to work your way down. If you want to prove the block hash of x-3 you would submit x, x-1, x-3.