### PR TITLE
Add a base OracleAdapter and a way to prove ancestral blocks

### DIFF
--- a/contracts/adapters/AMB/AMBAdapter.sol
+++ b/contracts/adapters/AMB/AMBAdapter.sol
@@ -2,15 +2,12 @@
 pragma solidity ^0.8.17;
 
 import "./IAMB.sol";
-import "../interfaces/IOracleAdapter.sol";
+import "../OracleAdapter.sol";
 
-contract AMBAdapter {
+contract AMBAdapter is OracleAdapter {
     IAMB public amb;
     address public reporter;
     bytes32 public chainId;
-    mapping(uint256 => bytes32) public hashes;
-
-    event HashStored(uint256 indexed id, bytes32 indexed hashes);
 
     error ArrayLengthMissmatch(address emitter);
     error UnauthorizedAMB(address emitter, address sender);
@@ -36,26 +33,10 @@ contract AMBAdapter {
     /// @param _hashes Array of hashes to set for the given ids.
     /// @notice Only callable by `amb` with a message passed from `reporter.
     /// @notice Will revert if given array lengths do not match.
-    function storeHashes(uint256[] memory ids, bytes32[] memory _hashes) public {
+    function storeHashes(uint256[] memory ids, bytes32[] memory _hashes) public onlyValid {
         if (ids.length != _hashes.length) revert ArrayLengthMissmatch(address(this));
         for (uint i = 0; i < ids.length; i++) {
-            _storeHash(ids[i], _hashes[i]);
+            _storeHash(uint256(chainId), ids[i], _hashes[i]);
         }
-    }
-
-    function _storeHash(uint256 id, bytes32 hash) internal onlyValid {
-        bytes32 currentHash = hashes[id];
-        if (currentHash != hash) {
-            hashes[id] = hash;
-            emit HashStored(id, hash);
-        }
-    }
-
-    /// @dev Returns the hash for a given ID, as reported by the AMB.
-    /// @param id Identifier for the ID to query.
-    /// @return hash Bytes32 hash reported by the oracle for the given ID on the given domain.
-    /// @notice MUST return bytes32(0) if the oracle has not yet reported a hash for the given ID.
-    function getHashFromOracle(uint256, uint256 id) external view returns (bytes32 hash) {
-        hash = hashes[id];
     }
 }

--- a/contracts/adapters/OracleAdapter.sol
+++ b/contracts/adapters/OracleAdapter.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import "./interfaces/IOracleAdapter.sol";
+
+abstract contract OracleAdapter is IOracleAdapter {
+    mapping(uint256 => mapping(uint256 => bytes32)) public hashes;
+
+    /// @dev Returns the hash for a given ID, as reported by the oracle.
+    /// @param domain Identifier for the domain to query.
+    /// @param id Identifier for the ID to query.
+    /// @return hash Bytes32 hash reported by the oracle for the given ID on the given domain.
+    /// @notice MUST return bytes32(0) if the oracle has not yet reported a hash for the given ID.
+    function getHashFromOracle(uint256 domain, uint256 id) external view returns (bytes32 hash) {
+        hash = hashes[domain][id];
+    }
+
+    function _storeHash(uint256 domain, uint256 id, bytes32 hash) internal {
+        bytes32 currentHash = hashes[domain][id];
+        if (currentHash != hash) {
+            hashes[domain][id] = hash;
+            emit HashStored(id, hash);
+        }
+    }
+}

--- a/contracts/adapters/OracleAdapter.sol
+++ b/contracts/adapters/OracleAdapter.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
+import "solidity-rlp/contracts/RLPReader.sol";
+
 import "./interfaces/IOracleAdapter.sol";
 
 abstract contract OracleAdapter is IOracleAdapter {
     mapping(uint256 => mapping(uint256 => bytes32)) public hashes;
+
+    using RLPReader for RLPReader.RLPItem;
 
     /// @dev Returns the hash for a given ID, as reported by the oracle.
     /// @param domain Identifier for the domain to query.
@@ -13,6 +17,31 @@ abstract contract OracleAdapter is IOracleAdapter {
     /// @notice MUST return bytes32(0) if the oracle has not yet reported a hash for the given ID.
     function getHashFromOracle(uint256 domain, uint256 id) external view returns (bytes32 hash) {
         hash = hashes[domain][id];
+    }
+
+    function proveAncestralBlockHashes(uint256 chainId, bytes[] memory blockHeaders) external {
+        for (uint256 i = 0; i < blockHeaders.length; i++) {
+            RLPReader.RLPItem memory blockHeaderRLP = RLPReader.toRlpItem(blockHeaders[i]);
+
+            if (!blockHeaderRLP.isList()) revert InvalidBlockHeaderRLP();
+
+            RLPReader.RLPItem[] memory blockHeaderContent = blockHeaderRLP.toList();
+
+            // A block header should have between 15 and 17 elements (baseFee and withdrawalsRoot have been added later)
+            if (blockHeaderContent.length < 15 || blockHeaderContent.length > 17)
+                revert InvalidBlockHeaderLength(blockHeaderContent.length);
+
+            bytes32 blockParent = bytes32(blockHeaderContent[0].toUint());
+            uint256 blockNumber = uint256(blockHeaderContent[8].toUint());
+
+            bytes32 reportedBlockHash = keccak256(blockHeaders[i]);
+            bytes32 storedBlockHash = hashes[chainId][blockNumber];
+
+            if (reportedBlockHash != storedBlockHash)
+                revert ConflictingBlockHeader(blockNumber, reportedBlockHash, storedBlockHash);
+
+            _storeHash(chainId, blockNumber - 1, blockParent);
+        }
     }
 
     function _storeHash(uint256 domain, uint256 id, bytes32 hash) internal {

--- a/contracts/adapters/Wormhole/WormholeAdapter.sol
+++ b/contracts/adapters/Wormhole/WormholeAdapter.sol
@@ -2,14 +2,11 @@
 pragma solidity ^0.8.17;
 
 import "./IWormhole.sol";
-import "../interfaces/IOracleAdapter.sol";
+import "../OracleAdapter.sol";
 
-contract WormholeAdapter {
+contract WormholeAdapter is OracleAdapter {
     IWormhole public wormhole;
     bytes32 public headerReporter;
-    mapping(uint256 => mapping(uint256 => bytes32)) public headers;
-
-    event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
 
     error InvalidMessage(address emitter, VM vm, string reason);
     error InvalidChainId(address emitter, uint16 chainId);
@@ -26,23 +23,11 @@ contract WormholeAdapter {
     /// @param vm Structured data reflecting the content of the Wormhole Verified Action Approval.
     /// @notice Only callable by `wormhole` with a message passed from `headerReporter.
     function storeBlockHeader(uint256 blockNumber, uint16 chainId, VM memory vm) public {
-        bytes32 currentBlockHeader = headers[uint256(chainId)][blockNumber];
         (VM memory _vm, bool valid, string memory reason) = wormhole.parseAndVerifyVM(abi.encode(vm));
         if (!valid) revert InvalidMessage(address(this), vm, reason);
         if (_vm.emitterChainId != chainId) revert InvalidChainId(address(this), _vm.emitterChainId);
         if (_vm.emitterAddress != headerReporter) revert InvalidReporter(address(this), _vm.emitterAddress);
-        bytes32 newBlockHeader = abi.decode(_vm.payload, (bytes32));
-        if (currentBlockHeader != newBlockHeader) {
-            headers[uint256(chainId)][blockNumber] = newBlockHeader;
-            emit HeaderStored(blockNumber, newBlockHeader);
-        }
-    }
-
-    /// @dev Returns the block header for a given block, as reported by the Wormhole.
-    /// @param blockNumber Identifier for the block to query.
-    /// @return blockHeader Bytes32 block header reported by the oracle for the given block on the given chain.
-    /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
-    function getHeaderFromOracle(uint256 chainId, uint256 blockNumber) external view returns (bytes32 blockHeader) {
-        blockHeader = headers[chainId][blockNumber];
+        bytes32 newHash = abi.decode(_vm.payload, (bytes32));
+        _storeHash(uint256(chainId), blockNumber, newHash);
     }
 }

--- a/contracts/adapters/interfaces/IOracleAdapter.sol
+++ b/contracts/adapters/interfaces/IOracleAdapter.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.17;
 interface IOracleAdapter {
     event HashStored(uint256 indexed id, bytes32 indexed hashes);
 
+    error InvalidBlockHeaderLength(uint256 length);
+    error InvalidBlockHeaderRLP();
+    error ConflictingBlockHeader(uint256 blockNumber, bytes32 reportedBlockHash, bytes32 storedBlockHash);
+
     /// @dev Returns the hash for a given ID, as reported by the oracle.
     /// @param domain Identifier for the domain to query.
     /// @param id Identifier for the ID to query.

--- a/contracts/adapters/interfaces/IOracleAdapter.sol
+++ b/contracts/adapters/interfaces/IOracleAdapter.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.8.17;
 
 interface IOracleAdapter {
-    /// @dev Returns the block header for a given block on a given chain.
+    event HashStored(uint256 indexed id, bytes32 indexed hashes);
+
+    /// @dev Returns the hash for a given ID, as reported by the oracle.
     /// @param domain Identifier for the domain to query.
-    /// @param id Identifier for which to return a hash.
-    /// @return hash Hash reported by the oracle for the given ID in the given domain.
-    /// @notice MUST return bytes32(0) if the oracle has not yet reported a header for the given block.
+    /// @param id Identifier for the ID to query.
+    /// @return hash Bytes32 hash reported by the oracle for the given ID on the given domain.
+    /// @notice MUST return bytes32(0) if the oracle has not yet reported a hash for the given ID.
     function getHashFromOracle(uint256 domain, uint256 id) external view returns (bytes32 hash);
 }

--- a/contracts/test/MockOracleAdapter.sol
+++ b/contracts/test/MockOracleAdapter.sol
@@ -1,21 +1,15 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import "../adapters/interfaces/IOracleAdapter.sol";
+import "../adapters/OracleAdapter.sol";
 
-contract MockOracleAdapter is IOracleAdapter {
-    mapping(uint256 => mapping(uint256 => bytes32)) public hashes;
-
+contract MockOracleAdapter is OracleAdapter {
     error LengthMismatch(address emitter);
-
-    function getHashFromOracle(uint256 domain, uint256 id) external view returns (bytes32 hash) {
-        hash = hashes[domain][id];
-    }
 
     function setHashes(uint256 domain, uint256[] memory ids, bytes32[] memory _hashes) external {
         if (ids.length != _hashes.length) revert LengthMismatch(address(this));
         for (uint i = 0; i < ids.length; i++) {
-            hashes[domain][ids[i]] = _hashes[i];
+            _storeHash(domain, ids[i], _hashes[i]);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   },
   "dependencies": {
     "@connext/interfaces": "^2.0.0",
-    "@openzeppelin/contracts-upgradeable": "^4.8.1"
+    "@openzeppelin/contracts-upgradeable": "^4.8.1",
+    "solidity-rlp": "^2.0.7"
   }
 }

--- a/test/adapters/02_OracleAdapter.spec.ts
+++ b/test/adapters/02_OracleAdapter.spec.ts
@@ -1,0 +1,137 @@
+import { expect } from "chai"
+import { RLP, hexlify } from "ethers/lib/utils"
+import { ethers, network } from "hardhat"
+
+const CHAIN_ID = 1
+const EMPTY_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+// Use evm_mine instead of hardhat_mine because hardhat_mine doesn't provide valid blocks
+const mine = async (n: number) => await Promise.all([...Array(n)].map(() => network.provider.send("evm_mine")))
+
+const emptyHexlify = (value: string) => {
+  const hex = ethers.utils.hexlify(value, { hexPad: "left" })
+  return hex === "0x00" ? "0x" : hex
+}
+
+const blockRLP = (block: any) => {
+  const values = [
+    block.parentHash,
+    block.sha3Uncles,
+    block.miner,
+    block.stateRoot,
+    block.transactionsRoot,
+    block.receiptsRoot,
+    block.logsBloom,
+    block.difficulty,
+    block.number,
+    block.gasLimit,
+    block.gasUsed,
+    block.timestamp,
+    block.extraData,
+    block.mixHash,
+    block.nonce,
+    block.baseFeePerGas,
+  ]
+  return RLP.encode(values.map(emptyHexlify))
+}
+
+const getBlock = async (blockNumber: number) => {
+  const block = await ethers.provider.send("eth_getBlockByNumber", [hexlify(blockNumber), false])
+  return {
+    ...block,
+    blockNumber,
+  }
+}
+
+const setup = async () => {
+  await network.provider.request({ method: "hardhat_reset", params: [] })
+  const [wallet] = await ethers.getSigners()
+  const OracleAdapter = await ethers.getContractFactory("MockOracleAdapter")
+  const oracleAdapter = await OracleAdapter.deploy()
+  await mine(120)
+  const reportedBlockNumbers = [100, 110]
+  const unreportedBlockNumbers = [109, 108, 107]
+  const blocks = await Promise.all(
+    reportedBlockNumbers.concat(unreportedBlockNumbers).map(async (blockNumber) => await getBlock(blockNumber)),
+  )
+  const reportedBlockHashes = blocks
+    .filter((block) => reportedBlockNumbers.includes(block.blockNumber))
+    .map((block) => block.hash)
+
+  await oracleAdapter.setHashes(CHAIN_ID, reportedBlockNumbers, reportedBlockHashes)
+  return {
+    wallet,
+    oracleAdapter,
+    reportedBlockNumbers,
+    reportedBlockHashes,
+    unreportedBlockNumbers,
+    blocks,
+  }
+}
+
+describe("OracleAdapter", function () {
+  describe("Deploy", function () {
+    it("Successfully deploys contract", async function () {
+      const { oracleAdapter } = await setup()
+      expect(await oracleAdapter.deployed())
+    })
+  })
+
+  describe("proveAncestralBlockHashes()", function () {
+    it("Adds ancestral block hashes of proven blocks", async function () {
+      const { oracleAdapter, blocks } = await setup()
+      const blockHeaders = blocks.map((block) => blockRLP(block))
+
+      // All blocks should have been proven and their ancestral headers stored
+      const tx = oracleAdapter.proveAncestralBlockHashes(CHAIN_ID, blockHeaders)
+      for (const block of blocks) {
+        await expect(tx)
+          .to.emit(oracleAdapter, "HashStored")
+          .withArgs(block.blockNumber - 1, block.parentHash)
+      }
+    })
+
+    it("Reverts if given unknown blocks", async function () {
+      const { oracleAdapter, blocks, unreportedBlockNumbers } = await setup()
+      const unreportedBlockNumber = unreportedBlockNumbers[0]
+      const unreportedBlock = blocks.find((block) => block.blockNumber === unreportedBlockNumber)
+      const blockHeaders = [blockRLP(unreportedBlock)]
+
+      await expect(oracleAdapter.proveAncestralBlockHashes(CHAIN_ID, blockHeaders))
+        .to.revertedWithCustomError(oracleAdapter, "ConflictingBlockHeader")
+        .withArgs(unreportedBlockNumber, unreportedBlock.hash, EMPTY_HASH)
+    })
+
+    it("Reverts if block header is invalid RLP encoding", async function () {
+      const { oracleAdapter } = await setup()
+      const invalidRLP = ["0xa0000000"]
+
+      // Invalid block header RLP
+      await expect(oracleAdapter.proveAncestralBlockHashes(CHAIN_ID, invalidRLP)).to.revertedWithCustomError(
+        oracleAdapter,
+        "InvalidBlockHeaderRLP",
+      )
+    })
+
+    it("Reverts if block proof doesn't match valid block header lengths", async function () {
+      const { oracleAdapter, blocks } = await setup()
+      const blockHeaderContents = RLP.decode(blockRLP(blocks[0]))
+      const blockHeaderTooShortContents = blockHeaderContents.slice(0, 14)
+      const blockHeaderTooShort = RLP.encode(blockHeaderTooShortContents)
+
+      // Block header RLP contains too few elements
+      await expect(oracleAdapter.proveAncestralBlockHashes(CHAIN_ID, [blockHeaderTooShort]))
+        .to.revertedWithCustomError(oracleAdapter, "InvalidBlockHeaderLength")
+        .withArgs(blockHeaderTooShortContents.length)
+
+      console.log(blockHeaderContents.length)
+      const blockHeaderTooLongContents = blockHeaderContents.concat([oracleAdapter.address, oracleAdapter.address])
+      const blockHeaderTooLong = RLP.encode(blockHeaderTooLongContents)
+
+      // Block header RLP contains too many elements
+      await expect(oracleAdapter.proveAncestralBlockHashes(CHAIN_ID, [blockHeaderTooLong]))
+        .to.revertedWithCustomError(oracleAdapter, "InvalidBlockHeaderLength")
+        .withArgs(blockHeaderTooLongContents.length)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,6 +1010,7 @@ __metadata:
     solhint: ^3.3.7
     solhint-plugin-prettier: ^0.0.5
     solidity-coverage: ^0.8.2
+    solidity-rlp: ^2.0.7
     ts-generator: ^0.1.1
     ts-node: ^10.9.1
     typechain: ^8.1.1
@@ -8987,6 +8988,13 @@ __metadata:
   bin:
     solidity-coverage: plugins/bin.js
   checksum: 489f73d56a1279f2394b7a14db315532884895baa00a4016e68a4e5be0eddca90a95cb3322e6a0b15e67f2d9003b9413ee24c1c61d78f558f5a2e1e233840825
+  languageName: node
+  linkType: hard
+
+"solidity-rlp@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "solidity-rlp@npm:2.0.7"
+  checksum: 05df8300ed3f1a99eab45177f7dfe95310e0eb1bce7808379285b4a8c5b9f1bb17f3a7ce778a9416889f3b7ecaeb2d365450507f89ca7f4c99e02ac90166e60f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Each adapter now uses the `OracleAdapter` as a base.

The OracleAdapter includes the `proveAncestralBlockHashes(uint256 chainId, bytes[] memory blockHeaders)` function which makes it possible to add block headers without having the reporter contract having to report them.

Say we have block x reported to the oracle. A user can then prove the ancestor of that block by sending it the RLP encoded block header. This would add the `parentHash` to the list of stored headers.

`proveAncestralBlockHashes` accepts an array of RLP encoded block headers. It will process the block headers in order so it's important to work your way down. If you want to prove the block hash of x-3 you would submit x, x-1, x-3.

(this is an updated version of PR #5)