### PR TITLE
add Telepathy via Light Client

### DIFF
--- a/contracts/adapters/Telepathy/TelepathyAdapter.sol
+++ b/contracts/adapters/Telepathy/TelepathyAdapter.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.17;
 
 import {ILightClient, TelepathyStorage} from "./interfaces/ITelepathy.sol";
 import {SSZ} from "./libraries/SimpleSerialize.sol";
-import {OracleAdapter} from "../OracleAdapter.sol";
+import {BlockHashOracleAdapter} from "../BlockHashOracleAdapter.sol";
 
-contract TelepathyAdapter is OracleAdapter {
+contract TelepathyAdapter is BlockHashOracleAdapter {
     error NoLightClientOnChain(uint32 chainId);
     error InconsistentLightClient(address lightClient);
     error BlockHeaderNotAvailable(uint256 slot);

--- a/contracts/adapters/Telepathy/TelepathyAdapter.sol
+++ b/contracts/adapters/Telepathy/TelepathyAdapter.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import {ILightClient, TelepathyStorage} from "./interfaces/ITelepathy.sol";
+import {SSZ} from "./libraries/SimpleSerialize.sol";
+import {OracleAdapter} from "../OracleAdapter.sol";
+
+contract TelepathyAdapter is OracleAdapter {
+    error NoLightClientOnChain(uint32 chainId);
+    error InconsistentLightClient(address lightClient);
+    error BlockHeaderNotAvailable(uint256 slot);
+    error InvalidBlockNumberProof();
+    error InvalidBlockHashProof();
+
+    /// @dev The Telepathy Router contains a mapping of chainIds to Light Clients.
+    address public immutable telepathyRouter;
+
+    constructor(address _telepathyRouter) {
+        telepathyRouter = _telepathyRouter;
+    }
+
+    /// @notice Stores the block header for a given block only if it exists in the Telepathy
+    ///         Light Client for the chainId.
+    function storeBlockHeader(
+        uint32 _chainId,
+        uint64 _slot,
+        uint256 _blockNumber,
+        bytes32[] calldata _blockNumberProof,
+        bytes32 _blockHash,
+        bytes32[] calldata _blockHashProof
+    ) external {
+        ILightClient lightClient = TelepathyStorage(telepathyRouter).lightClients(_chainId);
+        if (address(lightClient) == address(0)) {
+            revert NoLightClientOnChain(_chainId);
+        }
+        if (!lightClient.consistent()) {
+            revert InconsistentLightClient(address(lightClient));
+        }
+
+        bytes32 blockHeaderRoot = lightClient.headers(_slot);
+        if (blockHeaderRoot == bytes32(0)) {
+            revert BlockHeaderNotAvailable(_slot);
+        }
+
+        if (!SSZ.verifyBlockNumber(_blockNumber, _blockNumberProof, blockHeaderRoot)) {
+            revert InvalidBlockNumberProof();
+        }
+
+        if (!SSZ.verifyBlockHash(_blockHash, _blockHashProof, blockHeaderRoot)) {
+            revert InvalidBlockHashProof();
+        }
+
+        _storeHash(uint256(_chainId), _blockNumber, _blockHash);
+    }
+}

--- a/contracts/adapters/Telepathy/interfaces/ITelepathy.sol
+++ b/contracts/adapters/Telepathy/interfaces/ITelepathy.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+interface ILightClient {
+    function consistent() external view returns (bool);
+
+    function head() external view returns (uint256);
+
+    function headers(uint256 slot) external view returns (bytes32);
+
+    function executionStateRoots(uint256 slot) external view returns (bytes32);
+
+    function timestamps(uint256 slot) external view returns (uint256);
+}
+
+contract TelepathyStorage {
+    mapping(uint32 => ILightClient) public lightClients;
+}

--- a/contracts/adapters/Telepathy/libraries/SimpleSerialize.sol
+++ b/contracts/adapters/Telepathy/libraries/SimpleSerialize.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+library SSZ {
+    // G-indicies for the BeaconBlockHeader -> bodyRoot -> executionPayload -> {blockNumber, blockHash}
+    uint256 internal constant EXECUTION_PAYLOAD_BLOCK_NUMBER_INDEX = 3222;
+    uint256 internal constant EXECUTION_PAYLOAD_BLOCK_HASH_INDEX = 3228;
+
+    function toLittleEndian(uint256 _v) internal pure returns (bytes32) {
+        _v = ((_v & 0xFF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00) >> 8)
+            | ((_v & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+        _v = ((_v & 0xFFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000) >> 16)
+            | ((_v & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) << 16);
+        _v = ((_v & 0xFFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000) >> 32)
+            | ((_v & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) << 32);
+        _v = ((_v & 0xFFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF0000000000000000) >> 64)
+            | ((_v & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) << 64);
+        _v = (_v >> 128) | (_v << 128);
+        return bytes32(_v);
+    }
+
+    function restoreMerkleRoot(bytes32 _leaf, uint256 _index, bytes32[] memory _branch)
+        internal
+        pure
+        returns (bytes32)
+    {
+        require(2 ** (_branch.length + 1) > _index);
+        bytes32 value = _leaf;
+        uint256 i = 0;
+        while (_index != 1) {
+            if (_index % 2 == 1) {
+                value = sha256(bytes.concat(_branch[i], value));
+            } else {
+                value = sha256(bytes.concat(value, _branch[i]));
+            }
+            _index /= 2;
+            i++;
+        }
+        return value;
+    }
+
+    function isValidMerkleBranch(bytes32 _leaf, uint256 _index, bytes32[] memory _branch, bytes32 _root)
+        internal
+        pure
+        returns (bool)
+    {
+        bytes32 restoredMerkleRoot = restoreMerkleRoot(_leaf, _index, _branch);
+        return _root == restoredMerkleRoot;
+    }
+
+    function verifyBlockNumber(uint256 _blockNumber, bytes32[] memory _blockNumberProof, bytes32 _headerRoot)
+        internal
+        pure
+        returns (bool)
+    {
+        return isValidMerkleBranch(
+            toLittleEndian(_blockNumber), EXECUTION_PAYLOAD_BLOCK_NUMBER_INDEX, _blockNumberProof, _headerRoot
+        );
+    }
+
+    function verifyBlockHash(bytes32 _blockHash, bytes32[] memory _blockHashProof, bytes32 _headerRoot)
+        internal
+        pure
+        returns (bool)
+    {
+        return isValidMerkleBranch(_blockHash, EXECUTION_PAYLOAD_BLOCK_HASH_INDEX, _blockHashProof, _headerRoot);
+    }
+}


### PR DESCRIPTION
This PR adds the [Telepathy Protocol](https://www.telepathy.xyz/) to the [Hashi](https://ethresear.ch/t/hashi-a-principled-approach-to-bridges/14725) project.

This is achieved by a `TelepathyAdapter` that reads the [Router's](https://docs.telepathy.xyz/protocol/contracts#router) appropriate [Light Client](https://docs.telepathy.xyz/protocol/contracts#light-client) for the intended chain. 

The logic to read the headers from the Light Client is simple. However, because Hashi is concerned with `blockNumber` and `blockHash`, we need to prove these are for the intended slot. This is achieved by submitting Merkle Proofs for both: `BeaconBlockHeader` -> `bodyRoot` -> `executionPayload` -> {`blockNumber`, `blockHash`}

For more information on Telepathy, please see the [docs](https://docs.telepathy.xyz/)!