### PR TITLE
feat(evm): Add dendreth adapter

### DIFF
--- a/packages/evm/contracts/adapters/DendrETH/DendrETHAdapter.sol
+++ b/packages/evm/contracts/adapters/DendrETH/DendrETHAdapter.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { ILightClient } from "./interfaces/IDendrETH.sol";
+import { SSZ } from "../Telepathy/libraries/SimpleSerialize.sol";
+import { BlockHashOracleAdapter } from "../BlockHashOracleAdapter.sol";
+
+contract DendrETHAdapter is BlockHashOracleAdapter {
+    error BlockHeaderNotAvailable(uint256 slot);
+    error InvalidBlockNumberProof();
+    error InvalidBlockHashProof();
+
+    address public immutable dendrETHAddress;
+
+    constructor(address _dendrETHAddress) {
+        dendrETHAddress = _dendrETHAddress;
+    }
+
+    /// @notice Stores the block header for a given block only if it exists
+    //          in the DendrETH Light Client for the chainId.
+    function storeBlockHeader(
+        uint32 _chainId,
+        uint64 _slot,
+        uint256 _blockNumber,
+        bytes32[] calldata _blockNumberProof,
+        bytes32 _blockHash,
+        bytes32[] calldata _blockHashProof
+    ) external {
+        ILightClient lightClient = ILightClient(dendrETHAddress);
+
+        uint256 currentIndex = lightClient.currentIndex();
+        uint256 i = currentIndex;
+        bool found = false;
+
+        do {
+            if (_slot == lightClient.optimisticSlots(i)) {
+                found = true;
+                break;
+            }
+            if (i == 0) {
+                i = 32;
+            }
+            i--;
+        } while (i != currentIndex);
+
+        if (!found) {
+            revert BlockHeaderNotAvailable(_slot);
+        }
+
+        bytes32 blockHeaderRoot = lightClient.optimisticHeaders(i);
+
+        if (!SSZ.verifyBlockNumber(_blockNumber, _blockNumberProof, blockHeaderRoot)) {
+            revert InvalidBlockNumberProof();
+        }
+
+        if (!SSZ.verifyBlockHash(_blockHash, _blockHashProof, blockHeaderRoot)) {
+            revert InvalidBlockHashProof();
+        }
+
+        _storeHash(uint256(_chainId), _blockNumber, _blockHash);
+    }
+}

--- a/packages/evm/contracts/adapters/DendrETH/interfaces/IDendrETH.sol
+++ b/packages/evm/contracts/adapters/DendrETH/interfaces/IDendrETH.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.17;
+
+interface ILightClient {
+    function currentIndex() external view returns (uint256);
+
+    function optimisticHeaders(uint256 index) external view returns (bytes32);
+
+    function optimisticSlots(uint256 index) external view returns (uint256);
+}


### PR DESCRIPTION
The [DendrETH project](https://github.com/metacraft-labs/DendrETH) has implemented a zero-knowledge circuit capable of proving successful state transitions based on the beacon chain [light client sync protocol](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md). The project is currently aiming to implement a zero-knowledge circuit capable of proving the [Casper finality conditions](https://arxiv.org/abs/1710.09437) by processing the attestations messages of entire Ethereum validator set.

You can find out more about the project and see a list of our currently deployed instances here:

https://github.com/metacraft-labs/DendrETH