### PR TITLE
Dendreth adapter to update the oracle in the same transaction

### DIFF
--- a/packages/evm/contracts/adapters/DendrETH/DendrETHAdapter.sol
+++ b/packages/evm/contracts/adapters/DendrETH/DendrETHAdapter.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import { ILightClient } from "./interfaces/IDendrETH.sol";
+import { ILightClient, LightClientUpdate } from "./interfaces/IDendrETH.sol";
 import { SSZ } from "../Telepathy/libraries/SimpleSerialize.sol";
 import { BlockHashOracleAdapter } from "../BlockHashOracleAdapter.sol";
 
 contract DendrETHAdapter is BlockHashOracleAdapter {
+    error InvalidUpdate();
     error BlockHeaderNotAvailable(uint256 slot);
     error InvalidBlockNumberProof();
     error InvalidBlockHashProof();
@@ -48,6 +49,38 @@ contract DendrETHAdapter is BlockHashOracleAdapter {
         }
 
         bytes32 blockHeaderRoot = lightClient.optimisticHeaders(i);
+
+        if (!SSZ.verifyBlockNumber(_blockNumber, _blockNumberProof, blockHeaderRoot)) {
+            revert InvalidBlockNumberProof();
+        }
+
+        if (!SSZ.verifyBlockHash(_blockHash, _blockHashProof, blockHeaderRoot)) {
+            revert InvalidBlockHashProof();
+        }
+
+        _storeHash(uint256(_chainId), _blockNumber, _blockHash);
+    }
+
+    /// @notice Updates DendrETH Light client and stores the given block
+    //          for the update
+    function storeBlockHeader(
+        uint32 _chainId,
+        uint64 _slot,
+        uint256 _blockNumber,
+        bytes32[] calldata _blockNumberProof,
+        bytes32 _blockHash,
+        bytes32[] calldata _blockHashProof,
+        LightClientUpdate calldata update
+    ) external {
+        ILightClient lightClient = ILightClient(dendrETHAddress);
+
+        lightClient.light_client_update(update);
+
+        if (lightClient.optimisticHeaderSlot() != _slot) {
+            revert InvalidUpdate();
+        }
+
+        bytes32 blockHeaderRoot = lightClient.optimisticHeaderRoot();
 
         if (!SSZ.verifyBlockNumber(_blockNumber, _blockNumberProof, blockHeaderRoot)) {
             revert InvalidBlockNumberProof();

--- a/packages/evm/contracts/adapters/DendrETH/interfaces/IDendrETH.sol
+++ b/packages/evm/contracts/adapters/DendrETH/interfaces/IDendrETH.sol
@@ -1,10 +1,26 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity 0.8.17;
 
+struct LightClientUpdate {
+    bytes32 attestedHeaderRoot;
+    uint256 attestedHeaderSlot;
+    bytes32 finalizedHeaderRoot;
+    bytes32 finalizedExecutionStateRoot;
+    uint256[2] a;
+    uint256[2][2] b;
+    uint256[2] c;
+}
+
 interface ILightClient {
     function currentIndex() external view returns (uint256);
 
     function optimisticHeaders(uint256 index) external view returns (bytes32);
 
+    function optimisticHeaderRoot() external view returns (bytes32);
+
     function optimisticSlots(uint256 index) external view returns (uint256);
+
+    function optimisticHeaderSlot() external view returns (uint256);
+
+    function light_client_update(LightClientUpdate calldata update) external;
 }


### PR DESCRIPTION
Having both the adapter and oracle updated in the same transaction saves gas.
Currently, it costs 271,481 gas to update the oracle and 93,450 gas to update the adapter which accumulates to 364931 gas.
While it costs 338040 gas to update them in a single transaction.

Also updating them in a single transaction makes the relayer software simpler as it will need to make sure to publish only one transaction successfully on chain