### PR TITLE
ref: refactor ShuSo, ShoyuBashi and GiriGiriBashi & fix _getThresholdHash

### DIFF
--- a/packages/evm/contracts/interfaces/IGiriGiriBashi.sol
+++ b/packages/evm/contracts/interfaces/IGiriGiriBashi.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { IHashi } from "./IHashi.sol";
+import { IOracleAdapter } from "./IOracleAdapter.sol";
+import { IShuSho } from "./IShuSho.sol";
+
+/**
+ * @title IGiriGiriBashi
+ */
+interface IGiriGiriBashi is IShuSho {
+    struct Settings {
+        bool quarantined; // whether or not the adapter has has been quarantined.
+        uint256 minimumBond; // amount that must be bonded alongside a challenge.
+        uint256 startId; // earliest id that the oracle could have reported.
+        uint256 idDepth; // how far behind the current head can this oracle safely report. 0 equals infinite.
+        uint256 timeout; // grace period in which the oracle must report on an in range id after being challenged.
+    }
+
+    struct Challenge {
+        address payable challenger; // account that raised the challenge.
+        uint256 timestamp; // timestamp when the challenge was created.
+        uint256 bond; // bond paid by the challenger.
+    }
+
+    event BondRecipientSet(address payable bondRecipient);
+    event NewHead(uint256 domain, uint256 head);
+    event ChallegenRangeUpdated(uint256 domain, uint256 range);
+    event SettingsInitialized(uint256 domain, IOracleAdapter adapter, Settings settings);
+    event ChallengeCreated(
+        bytes32 challengeId,
+        uint256 indexed domain,
+        uint256 id,
+        IOracleAdapter indexed adapter,
+        address indexed challenger,
+        uint256 timestamp,
+        uint256 bond
+    );
+    event ChallengeResolved(
+        bytes32 challengeId,
+        uint256 indexed domain,
+        uint256 id,
+        IOracleAdapter indexed adapter,
+        address indexed challenger,
+        uint256 bond,
+        bool challengeSuccessful
+    );
+    event NoConfidenceDeclareed(uint256 domain);
+
+    error DuplicateChallenge(bytes32 challengeId, uint256 domain, uint256 id, IOracleAdapter adapter);
+    error OutOfRange(IOracleAdapter adapter, uint256 id);
+    error AlreadyQuarantined(IOracleAdapter adapter);
+    error NotEnoughtValue(IOracleAdapter adapter, uint256 value);
+    error ChallengeNotFound(bytes32 challengeId, uint256 domain, uint256 id, IOracleAdapter adapter);
+    error AdapterHasNotYetTimedOut(IOracleAdapter adapter);
+    error UnequalArrayLengths();
+    error AdapterNotQuarantined(IOracleAdapter adapter);
+    error CannotProveNoConfidence(uint256 domain, uint256 id, IOracleAdapter[] adapters);
+    error AdaptersAgreed(IOracleAdapter, IOracleAdapter);
+    error NoConfidenceRequired();
+    error CountMustBeZero(uint256 domain);
+    error ChallengeRangeAlreadySet(uint256 domain);
+
+    /**
+     * @dev Sets the threshold for a specific domain.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param threshold - The Uint256 threshold to set for the given domain.
+     */
+    function setThreshold(uint256 domain, uint256 threshold) external;
+
+    /**
+     * @dev Sets the bond recipient address for payments.
+     * @param bondRecipient - The address where bond payments should be sent.
+     */
+    function setBondRecipient(address payable bondRecipient) external;
+
+    /**
+     * @dev Sets the challenge range for a specific domain.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param range - The Uint256 range to set for the given domain.
+     */
+    function setChallengeRange(uint256 domain, uint256 range) external;
+
+    /**
+     * @dev Challenges the oracle adapter to provide a response. If the oracle adapter fails, it can be quarantined.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param  id - The Uint256 identifier for the challenge.
+     * @param adapter - The address of the oracle adapter to challenge.
+     * @notice Caller must pay a minimum bond to issue the challenge. This bond should be high enough to cover the gas costs for successfully completing the challenge.
+     */
+    function challengeOracleAdapter(uint256 domain, uint256 id, IOracleAdapter adapter) external payable;
+
+    /**
+     * @dev Resolves a challenge by comparing results from a specific oracle adapter with others.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param id - The Uint256 identifier.
+     * @param adapter - The oracle adapter instance for comparison.
+     * @param adapters - An array of oracle adapter instances for comparison.
+     * @return A boolean indicating the success of the challenge resolution.
+     */
+    function resolveChallenge(
+        uint256 domain,
+        uint256 id,
+        IOracleAdapter adapter,
+        IOracleAdapter[] memory adapters
+    ) external returns (bool);
+
+    /**
+     * @dev show that enough oracles disagree that they could not make a threshold if the remainder all agree with one.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param id - The Uint256 identifier.
+     * @param adapters - An array of oracle adapter instances.
+     */
+    function declareNoConfidence(uint256 domain, uint256 id, IOracleAdapter[] memory adapters) external;
+
+    /**
+     * @dev Replaces the quarantined oracle adapters for a given domain with new adapters and settings.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param currentAdapters - An array of current oracle adapter instances to be replaced.
+     * @param newAdapters - An array of new oracle adapter instances to replace the current ones.
+     * @param settings - An array of settings corresponding to the new adapters.
+     */
+    function replaceQuaratinedOrcales(
+        uint256 domain,
+        IOracleAdapter[] memory currentAdapters,
+        IOracleAdapter[] memory newAdapters,
+        Settings[] memory settings
+    ) external;
+
+    /**
+     * @dev Disables a set of oracle adapters for a given domain.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param adapters - An array of oracle adapter instances to be disabled.
+     */
+    function disableOracleAdapters(uint256 domain, IOracleAdapter[] memory adapters) external;
+
+    /**
+     * @dev Enables a set of oracle adapters for a given domain with specific settings.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param adapters - An array of oracle adapter instances.
+     * @param settings - An array of settings, corresponding to each adapter.
+     */
+    function enableOracleAdapters(
+        uint256 domain,
+        IOracleAdapter[] memory adapters,
+        Settings[] memory settings
+    ) external;
+
+    /**
+     * @dev Gets the challenge ID for a given domain, ID, and oracle adapter.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param id - The Uint256 identifier.
+     * @param adapter - The oracle adapter instance.
+     * @return The computed challenge ID as a bytes32 hash.
+     */
+    function getChallengeId(uint256 domain, uint256 id, IOracleAdapter adapter) external pure returns (bytes32);
+
+    /**
+     * @dev Returns the hash unanimously agreed upon by ALL of the enabled oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param id - Uint256 identifier to query.
+     * @return hash - Bytes32 hash agreed upon by the oracles for the given domain.
+     * @notice Reverts if oracles disagree.
+     * @notice Reverts if oracles have not yet reported the hash for the given ID.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
+    function getUnanimousHash(uint256 domain, uint256 id) external returns (bytes32 hash);
+
+    /**
+     * @dev Returns the hash agreed upon by a threshold of the enabled oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param id - Uint256 identifier to query.
+     * @return hash - Bytes32 hash agreed upon by a threshold of the oracles for the given domain.
+     * @notice Reverts if no threshold is not reached.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
+    function getThresholdHash(uint256 domain, uint256 id) external returns (bytes32 hash);
+
+    /**
+     * @dev Returns the hash unanimously agreed upon by all of the given oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param adapters - Array of oracle adapter addresses to query.
+     * @param id - Uint256 identifier to query.
+     * @return hash - Bytes32 hash agreed upon by the oracles for the given domain.
+     * @notice adapters must be in numerical order from smallest to largest and contain no duplicates.
+     * @notice Reverts if adapters are out of order or contain duplicates.
+     * @notice Reverts if oracles disagree.
+     * @notice Reverts if oracles have not yet reported the hash for the given ID.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
+    function getHash(uint256 domain, uint256 id, IOracleAdapter[] memory adapters) external returns (bytes32 hash);
+}

--- a/packages/evm/contracts/interfaces/IHashi.sol
+++ b/packages/evm/contracts/interfaces/IHashi.sol
@@ -18,6 +18,7 @@ interface IHashi {
      * @param id - ID for which to return hash.
      * @param threshold - Threshold to use.
      * @param oracleAdapters - Array of addresses for the oracle adapters to query.
+     * @notice If the threshold is 1, it will always return true.
      * @return result A boolean indicating if a threshold for a given message has been reached.
      */
     function checkHashWithThresholdFromOracles(

--- a/packages/evm/contracts/interfaces/IHeaderStorage.sol
+++ b/packages/evm/contracts/interfaces/IHeaderStorage.sol
@@ -5,9 +5,16 @@ pragma solidity ^0.8.17;
  * @title IHeaderStorage
  */
 interface IHeaderStorage {
-    error HeaderOutOfRange(address emitter, uint256 blockNumber);
+    error HeaderOutOfRange(uint256 blockNumber);
 
     event HeaderStored(uint256 indexed blockNumber, bytes32 indexed blockHeader);
+
+    /**
+     * @dev Retrieves the stored block header for a specific block number.
+     * @param blockNumber - The block number as a uint256 value.
+     * @return The block header as a bytes32 value.
+     */
+    function headers(uint256 blockNumber) external view returns (bytes32);
 
     /**
      * @dev Stores and returns the header for the given block.

--- a/packages/evm/contracts/interfaces/IShoyuBashi.sol
+++ b/packages/evm/contracts/interfaces/IShoyuBashi.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { IHashi } from "./IHashi.sol";
+import { IOracleAdapter } from "./IOracleAdapter.sol";
+import { IShuSho } from "./IShuSho.sol";
+
+/**
+ * @title IShoyuBashi
+ */
+interface IShoyuBashi is IShuSho {
+    /**
+     * @dev Sets the threshold of adapters required for a given domain.
+     * @param domain - Uint256 identifier for the domain for which to set the threshold.
+     * @param threshold - Uint256 threshold to set for the given domain.
+     * @notice Only callable by the owner of this contract.
+     * @notice Reverts if the threshold is already set to the given value.
+     */
+    function setThreshold(uint256 domain, uint256 threshold) external;
+
+    /**
+     * @dev Enables the given adapters for a given domain.
+     * @param domain - Uint256 identifier for the domain for which to set oracle adapters.
+     * @param adapters - Array of oracleAdapter addresses.
+     * @notice Reverts if adapters are out of order or contain duplicates.
+     * @notice Only callable by the owner of this contract.
+     */
+    function enableOracleAdapters(uint256 domain, IOracleAdapter[] memory adapters) external;
+
+    /**
+     * @dev Disables the given adapters for a given domain.
+     * @param domain - Uint256 identifier for the domain for which to set oracle adapters.
+     * @param adapters - Array of oracleAdapter addresses.
+     * @notice Reverts if adapters are out of order or contain duplicates.
+     * @notice Only callable by the owner of this contract.
+     */
+    function disableOracleAdapters(uint256 domain, IOracleAdapter[] memory adapters) external;
+
+    /**
+     * @dev Returns the hash unanimously agreed upon by ALL of the enabled oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param id - Uint256 identifier to query.
+     * @return Bytes32 hash agreed upon by the oracles for the given domain.
+     * @notice Reverts if oracles disagree.
+     * @notice Reverts if oracles have not yet reported the hash for the given ID.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
+    function getUnanimousHash(uint256 domain, uint256 id) external view returns (bytes32);
+
+    /**
+     * @dev Returns the hash agreed upon by a threshold of the enabled oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param id - Uint256 identifier to query.
+     * @return Bytes32 hash agreed upon by a threshold of the oracles for the given domain.
+     * @notice Reverts if the threshold is not reached.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
+    function getThresholdHash(uint256 domain, uint256 id) external view returns (bytes32);
+
+    /**
+     * @dev Returns the hash unanimously agreed upon by all of the given oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param adapters - Array of oracle adapter addresses to query.
+     * @param id - Uint256 identifier to query.
+     * @return Bytes32 hash agreed upon by the oracles for the given domain.
+     * @notice adapters must be in numerical order from smallest to largest and contain no duplicates.
+     * @notice Reverts if adapters are out of order or contain duplicates.
+     * @notice Reverts if oracles disagree.
+     * @notice Reverts if oracles have not yet reported the hash for the given ID.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
+    function getHash(uint256 domain, uint256 id, IOracleAdapter[] memory adapters) external view returns (bytes32);
+}

--- a/packages/evm/contracts/interfaces/IShuSho.sol
+++ b/packages/evm/contracts/interfaces/IShuSho.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { IHashi } from "./IHashi.sol";
+import { IOracleAdapter } from "./IOracleAdapter.sol";
+
+/**
+ * @title IShuSho
+ */
+interface IShuSho {
+    struct Link {
+        IOracleAdapter previous;
+        IOracleAdapter next;
+    }
+
+    event HashiSet(IHashi indexed hashi);
+    event Init(address indexed owner, IHashi indexed hashi);
+    event OracleAdaptersEnabled(uint256 indexed domain, IOracleAdapter[] adapters);
+    event OracleAdaptersDisabled(uint256 indexed domain, IOracleAdapter[] adapters);
+    event ThresholdSet(uint256 domain, uint256 threshold);
+
+    error AdapterNotEnabled(IOracleAdapter adapter);
+    error AdapterAlreadyEnabled(IOracleAdapter adapter);
+    error DuplicateHashiAddress(IHashi hashi);
+    error DuplicateOrOutOfOrderAdapters(IOracleAdapter adapterOne, IOracleAdapter adapterTwo);
+    error DuplicateThreashold(uint256 threshold);
+    error InvalidAdapter(IOracleAdapter adapter);
+    error NoAdaptersEnabled(uint256 domain);
+    error NoAdaptersGiven();
+    error ThresholdNotMet();
+
+    /**
+     * @dev Checks the order and validity of oracle adapters for a given domain.
+     * @param domain - The Uint256 identifier for the domain.
+     * @param _adapters - An array of oracle adapter instances.
+     */
+    function checkAdapterOrderAndValidity(uint256 domain, IOracleAdapter[] memory _adapters) external view;
+}

--- a/packages/evm/contracts/ownable/GiriGiriBashi.sol
+++ b/packages/evm/contracts/ownable/GiriGiriBashi.sol
@@ -1,125 +1,63 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import { IOracleAdapter, ShuSo, Hashi } from "./ShuSo.sol";
+import { ShuSo } from "./ShuSo.sol";
+import { IOracleAdapter } from "../interfaces/IOracleAdapter.sol";
+import { IHashi } from "../interfaces/IHashi.sol";
+import { IGiriGiriBashi } from "../interfaces/IGiriGiriBashi.sol";
 
-struct Settings {
-    bool quarantined; // whether or not the adapter has has been quarantined.
-    uint256 minimumBond; // amount that must be bonded alongside a challenge.
-    uint256 startId; // earliest id that the oracle could have reported.
-    uint256 idDepth; // how far behind the current head can this oracle safely report. 0 equals infinite.
-    uint256 timeout; // grace period in which the oracle must report on an in range id after being challenged.
-}
-
-struct Challenge {
-    address payable challenger; // account that raised the challenge.
-    uint256 timestamp; // timestamp when the challenge was created.
-    uint256 bond; // bond paid by the challenger.
-}
-
-contract GiriGiriBashi is ShuSo {
+contract GiriGiriBashi is IGiriGiriBashi, ShuSo {
     address payable public bondRecipient; // address that bonds from unsuccessful challenges should be sent to.
-
     mapping(uint256 => uint256) public heads; // highest Id reported.
     mapping(uint256 => uint256) public challengeRanges; // how far beyond the current highestId can a challenged.
     mapping(IOracleAdapter => Settings) public settings;
     mapping(bytes32 => Challenge) public challenges; // current challenges.
-
-    event BondRecipientSet(address emitter, address payable bondRecipient);
-    event NewHead(address emitter, uint256 domain, uint256 head);
-    event ChallegenRangeUpdated(address emitter, uint256 domain, uint256 range);
-    event SettingsInitialized(address emitter, uint256 domain, IOracleAdapter adapter, Settings settings);
-    event ChallengeCreated(
-        address emitter,
-        bytes32 challengeId,
-        uint256 indexed domain,
-        uint256 id,
-        IOracleAdapter indexed adapter,
-        address indexed challenger,
-        uint256 timestamp,
-        uint256 bond
-    );
-    event ChallengeResolved(
-        address emitter,
-        bytes32 challengeId,
-        uint256 indexed domain,
-        uint256 id,
-        IOracleAdapter indexed adapter,
-        address indexed challenger,
-        uint256 bond,
-        bool challengeSuccessful
-    );
-    event NoConfidenceDeclareed(address emitter, uint256 domain);
-
-    error DuplicateChallenge(address emitter, bytes32 challengeId, uint256 domain, uint256 id, IOracleAdapter adapter);
-    error OutOfRange(address emitter, IOracleAdapter adapter, uint256 id);
-    error AlreadyQuarantined(address emitter, IOracleAdapter adapter);
-    error NotEnoughtValue(address emitter, IOracleAdapter adapter, uint256 value);
-    error ChallengeNotFound(address emitter, bytes32 challengeId, uint256 domain, uint256 id, IOracleAdapter adapter);
-    error AdapterHasNotYetTimedOut(address emitter, IOracleAdapter adapter);
-    error UnequalArrayLengths(address emitter);
-    error AdapterNotQuarantined(address emitter, IOracleAdapter adapter);
-    error CannotProveNoConfidence(address emitter, uint256 domain, uint256 id, IOracleAdapter[] adapters);
-    error AdaptersAgreed(address emitter, IOracleAdapter, IOracleAdapter);
-    error NoConfidenceRequired(address emitter);
-    error CountMustBeZero(address emitter, uint256 domain);
-    error ChallengeRangeAlreadySet(address emitter, uint256 domain);
 
     constructor(address _owner, address _hashi, address payable _bondRecipient) ShuSo(_owner, _hashi) {
         bondRecipient = _bondRecipient;
     }
 
     modifier noConfidence(uint256 domain) {
-        if (domains[domain].threshold != type(uint256).max) revert NoConfidenceRequired(address(this));
+        if (domains[domain].threshold != type(uint256).max) revert NoConfidenceRequired();
         _;
     }
 
     modifier zeroCount(uint256 domain) {
-        if (domains[domain].count != 0) revert CountMustBeZero(address(this), domain);
+        if (domains[domain].count != 0) revert CountMustBeZero(domain);
         _;
     }
 
-    function setHashi(Hashi _hashi) public override onlyInitializing {
+    function setHashi(IHashi _hashi) public override onlyInitializing {
         _setHashi(_hashi);
     }
 
+    /// @inheritdoc IGiriGiriBashi
     function setThreshold(uint256 domain, uint256 threshold) public zeroCount(domain) {
         _setThreshold(domain, threshold);
     }
 
+    /// @inheritdoc IGiriGiriBashi
     function setBondRecipient(address payable _bondRecipient) public onlyOwner {
         bondRecipient = _bondRecipient;
-        emit BondRecipientSet(address(this), _bondRecipient);
+        emit BondRecipientSet(_bondRecipient);
     }
 
+    /// @inheritdoc IGiriGiriBashi
     function setChallengeRange(uint256 domain, uint256 range) public {
-        if (challengeRanges[domain] != 0) revert ChallengeRangeAlreadySet(address(this), domain);
+        if (challengeRanges[domain] != 0) revert ChallengeRangeAlreadySet(domain);
         challengeRanges[domain] = range;
-        emit ChallegenRangeUpdated(address(this), domain, range);
+        emit ChallegenRangeUpdated(domain, range);
     }
 
-    /// @dev Challenges the oracle adapter to provide a response.
-    /// If the oracle adapter fails, it can be quarantined.
-    /// @param domain Uint256 identifier for the domain for which to set the threshold.
-    /// @param id Uint256 threshold to set for the given domain.
-    /// @param adapter Address of the oracle adapter to challenge.
-    /// @notice Caller must pay a minimum bond to issue the challenge.
-    /// This bond should be high enough to cover the gas costs for successfully completing the challenge.
+    /// @inheritdoc IGiriGiriBashi
     function challengeOracleAdapter(uint256 domain, uint256 id, IOracleAdapter adapter) public payable {
-        // check if oracle is enabled, revert if false
-        if (adapters[domain][adapter].previous == IOracleAdapter(address(0)))
-            revert AdapterNotEnabled(address(this), adapter);
+        if (adapters[domain][adapter].previous == IOracleAdapter(address(0))) revert AdapterNotEnabled(adapter);
+        if (msg.value < settings[adapter].minimumBond) revert NotEnoughtValue(adapter, msg.value);
+        if (settings[adapter].quarantined) revert AlreadyQuarantined(adapter);
 
-        // check that msg.value is => greater than minimum bond for oracle, revert if false
-        if (msg.value < settings[adapter].minimumBond) revert NotEnoughtValue(address(this), adapter, msg.value);
-
-        // check if oracle is quarantined, revert if true
-        if (settings[adapter].quarantined) revert AlreadyQuarantined(address(this), adapter);
-
-        // check if challenge already exists, revert if true
         bytes32 challengeId = getChallengeId(domain, id, adapter);
         if (challenges[challengeId].challenger != address(0))
-            revert DuplicateChallenge(address(this), challengeId, domain, id, adapter);
+            revert DuplicateChallenge(challengeId, domain, id, adapter);
 
         // check if id is lower than startId, revert if true.
         // check if id is less than highestId + challengeRange, revert if false
@@ -131,18 +69,17 @@ contract GiriGiriBashi is ShuSo {
             id < settings[adapter].startId || // before start id
             (challengeRange != 0 && id >= head && id - head > challengeRange) || // over domain challenge range
             (idDepth != 0 && head > idDepth && id <= head - idDepth) // outside of adapter idDepth
-        ) revert OutOfRange(address(this), adapter, id);
+        ) revert OutOfRange(adapter, id);
 
-        // create challenge
         Challenge storage challenge = challenges[challengeId];
         challenge.challenger = payable(msg.sender);
         challenge.timestamp = block.timestamp;
         challenge.bond = msg.value;
 
-        // emit OracleAdapterChallenged
-        emit ChallengeCreated(address(this), challengeId, domain, id, adapter, msg.sender, block.timestamp, msg.value);
+        emit ChallengeCreated(challengeId, domain, id, adapter, msg.sender, block.timestamp, msg.value);
     }
 
+    /// @inheritdoc IGiriGiriBashi
     function resolveChallenge(
         uint256 domain,
         uint256 id,
@@ -152,7 +89,7 @@ contract GiriGiriBashi is ShuSo {
         // check if challenge exists, revert if false
         bytes32 challengeId = getChallengeId(domain, id, adapter);
         if (challenges[challengeId].challenger == address(0))
-            revert ChallengeNotFound(address(this), challengeId, domain, id, adapter);
+            revert ChallengeNotFound(challengeId, domain, id, adapter);
 
         // check if oracle has reported
         Challenge storage challenge = challenges[challengeId];
@@ -163,7 +100,7 @@ contract GiriGiriBashi is ShuSo {
         if (reportedHash == bytes32(0)) {
             // check block.timestamp is greater than challenge.timestamp + adapterSettings.timeout, revert if false.
             if (block.timestamp < challenge.timestamp + adapterSettings.timeout)
-                revert AdapterHasNotYetTimedOut(address(this), adapter);
+                revert AdapterHasNotYetTimedOut(adapter);
             // quaratine oracle adapter.
             adapterSettings.quarantined = true;
             // send bond to challenger
@@ -178,7 +115,7 @@ contract GiriGiriBashi is ShuSo {
                     bondRecipient.transfer(challenge.bond);
                     success = false;
                 } else {
-                    revert Hashi.OraclesDisagree(address(this), adapter, _adapters[0]);
+                    revert IHashi.OraclesDisagree(adapter, _adapters[0]);
                 }
             } else {
                 // check if _adapters report the same header as adapter
@@ -196,62 +133,37 @@ contract GiriGiriBashi is ShuSo {
                 }
             }
         }
-        emit ChallengeResolved(
-            address(this),
-            challengeId,
-            domain,
-            id,
-            adapter,
-            challenge.challenger,
-            challenge.bond,
-            success
-        );
-        // delete challenge
+        emit ChallengeResolved(challengeId, domain, id, adapter, challenge.challenger, challenge.bond, success);
+
         delete challenge.challenger;
         delete challenge.timestamp;
         delete challenge.bond;
     }
 
-    // show that enough oracles disagree that they could not make a threshold if the remainder all agree with one.
+    /// @inheritdoc IGiriGiriBashi
     function declareNoConfidence(uint256 domain, uint256 id, IOracleAdapter[] memory _adapters) public {
         checkAdapterOrderAndValidity(domain, _adapters);
         (uint256 threshold, uint256 count) = getThresholdAndCount(domain);
 
         // check that there are enough adapters to prove no confidence
         uint256 confidence = (count - _adapters.length) + 1;
-        if (confidence >= threshold) revert CannotProveNoConfidence(address(this), domain, id, _adapters);
+        if (confidence >= threshold) revert CannotProveNoConfidence(domain, id, _adapters);
 
-        // get hashes
         bytes32[] memory hashes = new bytes32[](_adapters.length);
         for (uint i = 0; i < _adapters.length; i++) hashes[i] = _adapters[i].getHashFromOracle(domain, id);
 
         // prove that each member of _adapters disagrees
         for (uint i = 0; i < hashes.length; i++)
             for (uint j = 0; j < hashes.length; j++)
-                if (hashes[i] == hashes[j] && i != j) revert AdaptersAgreed(address(this), _adapters[i], _adapters[j]);
+                if (hashes[i] == hashes[j] && i != j) revert AdaptersAgreed(_adapters[i], _adapters[j]);
 
-        // set no confidence
         domains[domain].threshold = type(uint256).max;
-
-        // clear state
         delete challengeRanges[domain];
 
-        emit NoConfidenceDeclareed(address(this), domain);
+        emit NoConfidenceDeclareed(domain);
     }
 
-    function initSettings(uint256 domain, IOracleAdapter[] memory _adapters, Settings[] memory _settings) private {
-        if (_adapters.length != _settings.length) revert UnequalArrayLengths(address(this));
-        for (uint i = 0; i < _adapters.length; i++) {
-            IOracleAdapter adapter = _adapters[i];
-            settings[adapter].quarantined = false;
-            settings[adapter].minimumBond = _settings[i].minimumBond;
-            settings[adapter].startId = _settings[i].startId;
-            settings[adapter].idDepth = _settings[i].idDepth;
-            settings[adapter].timeout = _settings[i].timeout;
-            emit SettingsInitialized(address(this), domain, adapter, _settings[i]);
-        }
-    }
-
+    /// @inheritdoc IGiriGiriBashi
     function replaceQuaratinedOrcales(
         uint256 domain,
         IOracleAdapter[] memory currentAdapters,
@@ -259,21 +171,22 @@ contract GiriGiriBashi is ShuSo {
         Settings[] memory _settings
     ) public onlyOwner {
         if (currentAdapters.length != newAdapters.length || currentAdapters.length != _settings.length)
-            revert UnequalArrayLengths(address(this));
+            revert UnequalArrayLengths();
         for (uint i = 0; i < currentAdapters.length; i++) {
-            if (!settings[currentAdapters[i]].quarantined)
-                revert AdapterNotQuarantined(address(this), currentAdapters[i]);
+            if (!settings[currentAdapters[i]].quarantined) revert AdapterNotQuarantined(currentAdapters[i]);
         }
         _disableOracleAdapters(domain, currentAdapters);
         _enableOracleAdapters(domain, newAdapters);
         initSettings(domain, newAdapters, _settings);
     }
 
+    /// @inheritdoc IGiriGiriBashi
     function disableOracleAdapters(uint256 domain, IOracleAdapter[] memory _adapters) public noConfidence(domain) {
         _disableOracleAdapters(domain, _adapters);
         if (domains[domain].count == 0) domains[domain].threshold = 0;
     }
 
+    /// @inheritdoc IGiriGiriBashi
     function enableOracleAdapters(
         uint256 domain,
         IOracleAdapter[] memory _adapters,
@@ -283,11 +196,7 @@ contract GiriGiriBashi is ShuSo {
         initSettings(domain, _adapters, _settings);
     }
 
-    function updateHead(uint256 domain, uint256 id) private {
-        if (id > heads[domain]) heads[domain] = id;
-        emit NewHead(address(this), domain, id);
-    }
-
+    /// @inheritdoc IGiriGiriBashi
     function getChallengeId(
         uint256 domain,
         uint256 id,
@@ -296,41 +205,39 @@ contract GiriGiriBashi is ShuSo {
         challengeId = keccak256(abi.encodePacked(domain, id, adapter));
     }
 
-    /// @dev Returns the hash unanimously agreed upon by ALL of the enabled oraclesAdapters.
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by the oracles for the given domain.
-    /// @notice Reverts if oracles disagree.
-    /// @notice Reverts if oracles have not yet reported the hash for the given ID.
-    /// @notice Reverts if no oracles are set for the given domain.
+    /// @inheritdoc IGiriGiriBashi
     function getUnanimousHash(uint256 domain, uint256 id) public returns (bytes32 hash) {
         hash = _getUnanimousHash(domain, id);
         updateHead(domain, id);
     }
 
-    /// @dev Returns the hash agreed upon by a threshold of the enabled oraclesAdapters.
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by a threshold of the oracles for the given domain.
-    /// @notice Reverts if no threshold is not reached.
-    /// @notice Reverts if no oracles are set for the given domain.
+    /// @inheritdoc IGiriGiriBashi
     function getThresholdHash(uint256 domain, uint256 id) public returns (bytes32 hash) {
         hash = _getThresholdHash(domain, id);
         updateHead(domain, id);
     }
 
-    /// @dev Returns the hash unanimously agreed upon by all of the given oraclesAdapters..
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param _adapters Array of oracle adapter addresses to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by the oracles for the given domain.
-    /// @notice _adapters must be in numberical order from smallest to largest and contain no duplicates.
-    /// @notice Reverts if _adapters are out of order or contain duplicates.
-    /// @notice Reverts if oracles disagree.
-    /// @notice Reverts if oracles have not yet reported the hash for the given ID.
-    /// @notice Reverts if no oracles are set for the given domain.
+    /// @inheritdoc IGiriGiriBashi
     function getHash(uint256 domain, uint256 id, IOracleAdapter[] memory _adapters) public returns (bytes32 hash) {
         hash = _getHash(domain, id, _adapters);
         updateHead(domain, id);
+    }
+
+    function initSettings(uint256 domain, IOracleAdapter[] memory _adapters, Settings[] memory _settings) private {
+        if (_adapters.length != _settings.length) revert UnequalArrayLengths();
+        for (uint i = 0; i < _adapters.length; i++) {
+            IOracleAdapter adapter = _adapters[i];
+            settings[adapter].quarantined = false;
+            settings[adapter].minimumBond = _settings[i].minimumBond;
+            settings[adapter].startId = _settings[i].startId;
+            settings[adapter].idDepth = _settings[i].idDepth;
+            settings[adapter].timeout = _settings[i].timeout;
+            emit SettingsInitialized(domain, adapter, _settings[i]);
+        }
+    }
+
+    function updateHead(uint256 domain, uint256 id) private {
+        if (id > heads[domain]) heads[domain] = id;
+        emit NewHead(domain, id);
     }
 }

--- a/packages/evm/contracts/ownable/ShoyuBashi.sol
+++ b/packages/evm/contracts/ownable/ShoyuBashi.sol
@@ -1,78 +1,45 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import { Hashi, IOracleAdapter, ShuSo, OwnableUpgradeable } from "./ShuSo.sol";
-import { Domain } from "../interfaces/IDomain.sol";
+import { ShuSo } from "./ShuSo.sol";
+import { IOracleAdapter } from "../interfaces/IOracleAdapter.sol";
+import { IHashi } from "../interfaces/IHashi.sol";
+import { IShoyuBashi } from "../interfaces/IShoyuBashi.sol";
 
-contract ShoyuBashi is ShuSo {
+contract ShoyuBashi is IShoyuBashi, ShuSo {
     constructor(address _owner, address _hashi) ShuSo(_owner, _hashi) {} // solhint-disable no-empty-blocks
 
-    /// @dev Sets the address of the Hashi contract.
-    /// @param _hashi Address of the hashi contract.
-    /// @notice Only callable by the owner of this contract.
-    function setHashi(Hashi _hashi) public override {
+    function setHashi(IHashi _hashi) public override {
         _setHashi(_hashi);
     }
 
-    /// @dev Sets the threshold of adapters required for a given domain.
-    /// @param domain Uint256 identifier for the domain for which to set the threshold.
-    /// @param threshold Uint256 threshold to set for the given domain.
-    /// @notice Only callable by the owner of this contract.
-    /// @notice Reverts if threshold is already set to the given value.
+    /// @inheritdoc IShoyuBashi
     function setThreshold(uint256 domain, uint256 threshold) public {
         _setThreshold(domain, threshold);
     }
 
-    /// @dev Enables the given adapters for a given domain.
-    /// @param domain Uint256 identifier for the domain for which to set oracle adapters.
-    /// @param _adapters Array of oracleAdapter addresses.
-    /// @notice Reverts if _adapters are out of order or contain duplicates.
-    /// @notice Only callable by the owner of this contract.
+    /// @inheritdoc IShoyuBashi
     function enableOracleAdapters(uint256 domain, IOracleAdapter[] memory _adapters) public {
         _enableOracleAdapters(domain, _adapters);
     }
 
-    /// @dev Disables the given adapters for a given domain.
-    /// @param domain Uint256 identifier for the domain for which to set oracle adapters.
-    /// @param _adapters Array of oracleAdapter addresses.
-    /// @notice Reverts if _adapters are out of order or contain duplicates.
-    /// @notice Only callable by the owner of this contract.
+    /// @inheritdoc IShoyuBashi
     function disableOracleAdapters(uint256 domain, IOracleAdapter[] memory _adapters) public {
         _disableOracleAdapters(domain, _adapters);
     }
 
-    /// @dev Returns the hash unanimously agreed upon by ALL of the enabled oraclesAdapters.
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by the oracles for the given domain.
-    /// @notice Reverts if oracles disagree.
-    /// @notice Reverts if oracles have not yet reported the hash for the given ID.
-    /// @notice Reverts if no oracles are set for the given domain.
-    function getUnanimousHash(uint256 domain, uint256 id) public view returns (bytes32 hash) {
-        hash = _getUnanimousHash(domain, id);
+    /// @inheritdoc IShoyuBashi
+    function getUnanimousHash(uint256 domain, uint256 id) public view returns (bytes32) {
+        return _getUnanimousHash(domain, id);
     }
 
-    /// @dev Returns the hash agreed upon by a threshold of the enabled oraclesAdapters.
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by a threshold of the oracles for the given domain.
-    /// @notice Reverts if no threshold is not reached.
-    /// @notice Reverts if no oracles are set for the given domain.
-    function getThresholdHash(uint256 domain, uint256 id) public view returns (bytes32 hash) {
-        hash = _getThresholdHash(domain, id);
+    /// @inheritdoc IShoyuBashi
+    function getThresholdHash(uint256 domain, uint256 id) public view returns (bytes32) {
+        return _getThresholdHash(domain, id);
     }
 
-    /// @dev Returns the hash unanimously agreed upon by all of the given oraclesAdapters..
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param _adapters Array of oracle adapter addresses to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by the oracles for the given domain.
-    /// @notice _adapters must be in numberical order from smallest to largest and contain no duplicates.
-    /// @notice Reverts if _adapters are out of order or contain duplicates.
-    /// @notice Reverts if oracles disagree.
-    /// @notice Reverts if oracles have not yet reported the hash for the given ID.
-    /// @notice Reverts if no oracles are set for the given domain.
-    function getHash(uint256 domain, uint256 id, IOracleAdapter[] memory _adapters) public view returns (bytes32 hash) {
-        hash = _getHash(domain, id, _adapters);
+    /// @inheritdoc IShoyuBashi
+    function getHash(uint256 domain, uint256 id, IOracleAdapter[] memory _adapters) public view returns (bytes32) {
+        return _getHash(domain, id, _adapters);
     }
 }

--- a/packages/evm/contracts/ownable/ShuSo.sol
+++ b/packages/evm/contracts/ownable/ShuSo.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import { IHashi } from "../interfaces/IHashi.sol";
-import { IOracleAdapter } from "../interfaces/IOracleAdapter.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { IOracleAdapter } from "../interfaces/IOracleAdapter.sol";
+import { IHashi } from "../interfaces/IHashi.sol";
 import { Domain } from "../interfaces/IDomain.sol";
 import { IShuSho } from "../interfaces/IShuSho.sol";
 
@@ -164,6 +164,7 @@ abstract contract ShuSo is IShuSho, OwnableUpgradeable {
      * @param domain - Uint256 identifier for the domain to query.
      * @param id - Uint256 identifier to query.
      * @return hash - Bytes32 hash agreed upon by a threshold of the oracles for the given domain.
+     * @notice If the threshold is set to 1, the function will return the hash of the first adapter in the list.
      * @notice Reverts if no threshold is not reached.
      * @notice Reverts if no oracles are set for the given domain.
      */
@@ -187,11 +188,10 @@ abstract contract ShuSo is IShuSho, OwnableUpgradeable {
             if (baseHash == bytes32(0)) continue;
 
             // increment num for each instance of the curent hash
-            uint256 num = 1;
+            uint256 num = 0;
             for (uint j = 0; j < hashes.length; j++) {
-                if (baseHash == hashes[j] && i != j) {
+                if (baseHash == hashes[j]) {
                     num++;
-                    // return current hash if num equals threshold
                     if (num == threshold) return hashes[i];
                 }
             }

--- a/packages/evm/contracts/ownable/ShuSo.sol
+++ b/packages/evm/contracts/ownable/ShuSo.sol
@@ -1,37 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import { Hashi, IOracleAdapter } from "../Hashi.sol";
+import { IHashi } from "../interfaces/IHashi.sol";
+import { IOracleAdapter } from "../interfaces/IOracleAdapter.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Domain } from "../interfaces/IDomain.sol";
+import { IShuSho } from "../interfaces/IShuSho.sol";
 
-struct Link {
-    IOracleAdapter previous;
-    IOracleAdapter next;
-}
-
-abstract contract ShuSo is OwnableUpgradeable {
+abstract contract ShuSo is IShuSho, OwnableUpgradeable {
     IOracleAdapter internal constant LIST_END = IOracleAdapter(address(0x1));
 
-    Hashi public hashi;
+    IHashi public hashi;
     mapping(uint256 => mapping(IOracleAdapter => Link)) public adapters;
     mapping(uint256 => Domain) public domains;
-
-    event HashiSet(address indexed emitter, Hashi indexed hashi);
-    event Init(address indexed emitter, address indexed owner, Hashi indexed hashi);
-    event OracleAdaptersEnabled(address indexed emitter, uint256 indexed domain, IOracleAdapter[] adapters);
-    event OracleAdaptersDisabled(address indexed emitter, uint256 indexed domain, IOracleAdapter[] adapters);
-    event ThresholdSet(address indexed emitter, uint256 domain, uint256 threshold);
-
-    error AdapterNotEnabled(address emitter, IOracleAdapter adapter);
-    error AdapterAlreadyEnabled(address emitter, IOracleAdapter adapter);
-    error DuplicateHashiAddress(address emitter, Hashi hashi);
-    error DuplicateOrOutOfOrderAdapters(address emitter, IOracleAdapter adapterOne, IOracleAdapter adapterTwo);
-    error DuplicateThreashold(address emitter, uint256 threshold);
-    error InvalidAdapter(address emitter, IOracleAdapter adapter);
-    error NoAdaptersEnabled(address emitter, uint256 domain);
-    error NoAdaptersGiven(address emitter);
-    error ThresholdNotMet(address emitter);
 
     constructor(address _owner, address _hashi) {
         bytes memory initParams = abi.encode(_owner, _hashi);
@@ -39,52 +20,56 @@ abstract contract ShuSo is OwnableUpgradeable {
     }
 
     function init(bytes memory initParams) public initializer {
-        (address _owner, Hashi _hashi) = abi.decode(initParams, (address, Hashi));
+        (address _owner, IHashi _hashi) = abi.decode(initParams, (address, IHashi));
         __Ownable_init();
         setHashi(_hashi);
         transferOwnership(_owner);
-        emit Init(address(this), _owner, _hashi);
+        emit Init(_owner, _hashi);
     }
 
-    function setHashi(Hashi _hashi) public virtual;
+    function setHashi(IHashi _hashi) public virtual;
 
-    /// @dev Sets the address of the Hashi contract.
-    /// @param _hashi Address of the hashi contract.
-    /// @notice Only callable by the owner of this contract.
-    function _setHashi(Hashi _hashi) internal onlyOwner {
-        if (hashi == _hashi) revert DuplicateHashiAddress(address(this), _hashi);
+    /**
+     * @dev Sets the address of the IHashi contract.
+     * @param _hashi - Address of the hashi contract.
+     * @notice Only callable by the owner of this contract.
+     */
+    function _setHashi(IHashi _hashi) internal onlyOwner {
+        if (hashi == _hashi) revert DuplicateHashiAddress(_hashi);
         hashi = _hashi;
-        emit HashiSet(address(this), hashi);
+        emit HashiSet(hashi);
     }
 
-    /// @dev Sets the threshold of adapters required for a given domain.
-    /// @param domain Uint256 identifier for the domain for which to set the threshold.
-    /// @param threshold Uint256 threshold to set for the given domain.
-    /// @notice Only callable by the owner of this contract.
-    /// @notice Reverts if threshold is already set to the given value.
+    /**
+     * @dev Sets the threshold of adapters required for a given domain.
+     * @param domain - Uint256 identifier for the domain for which to set the threshold.
+     * @param threshold - Uint256 threshold to set for the given domain.
+     * @notice Only callable by the owner of this contract.
+     * @notice Reverts if threshold is already set to the given value.
+     */
     function _setThreshold(uint256 domain, uint256 threshold) internal onlyOwner {
-        if (domains[domain].threshold == threshold) revert DuplicateThreashold(address(this), threshold);
+        if (domains[domain].threshold == threshold) revert DuplicateThreashold(threshold);
         domains[domain].threshold = threshold;
-        emit ThresholdSet(address(this), domain, threshold);
+        emit ThresholdSet(domain, threshold);
     }
 
-    /// @dev Enables the given adapters for a given domain.
-    /// @param domain Uint256 identifier for the domain for which to set oracle adapters.
-    /// @param _adapters Array of oracleAdapter addresses.
-    /// @notice Reverts if _adapters are out of order or contain duplicates.
-    /// @notice Only callable by the owner of this contract.
+    /**
+     * @dev Enables the given adapters for a given domain.
+     * @param domain - Uint256 identifier for the domain for which to set oracle adapters.
+     * @param _adapters - Array of oracleAdapter addresses.
+     * @notice Reverts if _adapters are out of order or contain duplicates.
+     * @notice Only callable by the owner of this contract.
+     */
     function _enableOracleAdapters(uint256 domain, IOracleAdapter[] memory _adapters) internal onlyOwner {
         if (adapters[domain][LIST_END].next == IOracleAdapter(address(0))) {
             adapters[domain][LIST_END].next = LIST_END;
             adapters[domain][LIST_END].previous = LIST_END;
         }
-        if (_adapters.length == 0) revert NoAdaptersGiven(address(this));
+        if (_adapters.length == 0) revert NoAdaptersGiven();
         for (uint256 i = 0; i < _adapters.length; i++) {
             IOracleAdapter adapter = _adapters[i];
-            if (adapter == IOracleAdapter(address(0)) || adapter == LIST_END)
-                revert InvalidAdapter(address(this), adapter);
-            if (adapters[domain][adapter].next != IOracleAdapter(address(0)))
-                revert AdapterAlreadyEnabled(address(this), adapter);
+            if (adapter == IOracleAdapter(address(0)) || adapter == LIST_END) revert InvalidAdapter(adapter);
+            if (adapters[domain][adapter].next != IOracleAdapter(address(0))) revert AdapterAlreadyEnabled(adapter);
             IOracleAdapter previous = adapters[domain][LIST_END].previous;
             adapters[domain][previous].next = adapter;
             adapters[domain][adapter].previous = previous;
@@ -92,23 +77,24 @@ abstract contract ShuSo is OwnableUpgradeable {
             adapters[domain][adapter].next = LIST_END;
             domains[domain].count++;
         }
-        emit OracleAdaptersEnabled(address(this), domain, _adapters);
+        emit OracleAdaptersEnabled(domain, _adapters);
     }
 
-    /// @dev Disables the given adapters for a given domain.
-    /// @param domain Uint256 identifier for the domain for which to set oracle adapters.
-    /// @param _adapters Array of oracleAdapter addresses.
-    /// @notice Reverts if _adapters are out of order or contain duplicates.
-    /// @notice Only callable by the owner of this contract.
+    /**
+     * @dev Disables the given adapters for a given domain.
+     * @param domain - Uint256 identifier for the domain for which to set oracle adapters.
+     * @param _adapters - Array of oracleAdapter addresses.
+     * @notice Reverts if _adapters are out of order or contain duplicates.
+     * @notice Only callable by the owner of this contract.
+     */
     function _disableOracleAdapters(uint256 domain, IOracleAdapter[] memory _adapters) internal onlyOwner {
-        if (domains[domain].count == 0) revert NoAdaptersEnabled(address(this), domain);
-        if (_adapters.length == 0) revert NoAdaptersGiven(address(this));
+        if (domains[domain].count == 0) revert NoAdaptersEnabled(domain);
+        if (_adapters.length == 0) revert NoAdaptersGiven();
         for (uint256 i = 0; i < _adapters.length; i++) {
             IOracleAdapter adapter = _adapters[i];
-            if (adapter == IOracleAdapter(address(0)) || adapter == LIST_END)
-                revert InvalidAdapter(address(this), adapter);
+            if (adapter == IOracleAdapter(address(0)) || adapter == LIST_END) revert InvalidAdapter(adapter);
             Link memory current = adapters[domain][adapter];
-            if (current.next == IOracleAdapter(address(0))) revert AdapterNotEnabled(address(this), adapter);
+            if (current.next == IOracleAdapter(address(0))) revert AdapterNotEnabled(adapter);
             IOracleAdapter next = current.next;
             IOracleAdapter previous = current.previous;
             adapters[domain][next].previous = previous;
@@ -117,11 +103,13 @@ abstract contract ShuSo is OwnableUpgradeable {
             delete adapters[domain][adapter].previous;
             domains[domain].count--;
         }
-        emit OracleAdaptersDisabled(address(this), domain, _adapters);
+        emit OracleAdaptersDisabled(domain, _adapters);
     }
 
-    /// @dev Returns an array of enabled oracle adapters for a given domain.
-    /// @param domain Uint256 identifier for the domain for which to list oracle adapters.
+    /**
+     * @dev Returns an array of enabled oracle adapters for a given domain.
+     * @param domain - Uint256 identifier for the domain for which to list oracle adapters.
+     */
     function getOracleAdapters(uint256 domain) public view returns (IOracleAdapter[] memory) {
         IOracleAdapter[] memory _adapters = new IOracleAdapter[](domains[domain].count);
         IOracleAdapter currentAdapter = adapters[domain][LIST_END].next;
@@ -132,54 +120,58 @@ abstract contract ShuSo is OwnableUpgradeable {
         return _adapters;
     }
 
-    /// @dev Returns the threshold and count for a given domain
-    /// @param domain Uint256 identifier for the domain.
-    /// @return threshold Uint256 oracle threshold for the given domain.
-    /// @return count Uint256 oracle count for the given domain.
-    /// @notice If the threshold for a domain has not been set, or is explicitly set to 0, this function will return a
-    /// threshold equal to the oracle count for the given domain.
+    /**
+     * @dev Returns the threshold and count for a given domain.
+     * @param domain - Uint256 identifier for the domain.
+     * @return threshold - Uint256 oracle threshold for the given domain.
+     * @return count - Uint256 oracle count for the given domain.
+     * @notice If the threshold for a domain has not been set, or is explicitly set to 0, this function will return a threshold equal to the oracle count for the given domain.
+     */
     function getThresholdAndCount(uint256 domain) public view returns (uint256 threshold, uint256 count) {
         threshold = domains[domain].threshold;
         count = domains[domain].count;
         if (threshold == 0) threshold = count;
     }
 
+    /// @inheritdoc IShuSho
     function checkAdapterOrderAndValidity(uint256 domain, IOracleAdapter[] memory _adapters) public view {
         for (uint256 i = 0; i < _adapters.length; i++) {
             IOracleAdapter adapter = _adapters[i];
-            if (i > 0 && adapter <= _adapters[i - 1])
-                revert DuplicateOrOutOfOrderAdapters(address(this), adapter, _adapters[i - 1]);
-            if (adapters[domain][adapter].next == IOracleAdapter(address(0)))
-                revert InvalidAdapter(address(this), adapter);
+            if (i > 0 && adapter <= _adapters[i - 1]) revert DuplicateOrOutOfOrderAdapters(adapter, _adapters[i - 1]);
+            if (adapters[domain][adapter].next == IOracleAdapter(address(0))) revert InvalidAdapter(adapter);
         }
     }
 
-    /// @dev Returns the hash unanimously agreed upon by ALL of the enabled oraclesAdapters.
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by the oracles for the given domain.
-    /// @notice Reverts if oracles disagree.
-    /// @notice Reverts if oracles have not yet reported the hash for the given ID.
-    /// @notice Reverts if no oracles are set for the given domain.
+    /**
+     * @dev Returns the hash unanimously agreed upon by ALL of the enabled oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param id - Uint256 identifier to query.
+     * @return hash - Bytes32 hash agreed upon by the oracles for the given domain.
+     * @notice Reverts if oracles disagree.
+     * @notice Reverts if oracles have not yet reported the hash for the given ID.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
     function _getUnanimousHash(uint256 domain, uint256 id) internal view returns (bytes32 hash) {
         IOracleAdapter[] memory _adapters = getOracleAdapters(domain);
         (uint256 threshold, uint256 count) = getThresholdAndCount(domain);
-        if (count == 0) revert NoAdaptersEnabled(address(this), domain);
-        if (_adapters.length < threshold) revert ThresholdNotMet(address(this));
+        if (count == 0) revert NoAdaptersEnabled(domain);
+        if (_adapters.length < threshold) revert ThresholdNotMet();
         hash = hashi.getHash(domain, id, _adapters);
     }
 
-    /// @dev Returns the hash agreed upon by a threshold of the enabled oraclesAdapters.
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by a threshold of the oracles for the given domain.
-    /// @notice Reverts if no threshold is not reached.
-    /// @notice Reverts if no oracles are set for the given domain.
+    /**
+     * @dev Returns the hash agreed upon by a threshold of the enabled oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param id - Uint256 identifier to query.
+     * @return hash - Bytes32 hash agreed upon by a threshold of the oracles for the given domain.
+     * @notice Reverts if no threshold is not reached.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
     function _getThresholdHash(uint256 domain, uint256 id) internal view returns (bytes32 hash) {
         IOracleAdapter[] memory _adapters = getOracleAdapters(domain);
         (uint256 threshold, uint256 count) = getThresholdAndCount(domain);
-        if (count == 0) revert NoAdaptersEnabled(address(this), domain);
-        if (_adapters.length < threshold) revert ThresholdNotMet(address(this));
+        if (count == 0) revert NoAdaptersEnabled(domain);
+        if (_adapters.length < threshold) revert ThresholdNotMet();
 
         // get hashes
         bytes32[] memory hashes = new bytes32[](_adapters.length);
@@ -204,28 +196,30 @@ abstract contract ShuSo is OwnableUpgradeable {
                 }
             }
         }
-        revert ThresholdNotMet(address(this));
+        revert ThresholdNotMet();
     }
 
-    /// @dev Returns the hash unanimously agreed upon by all of the given oraclesAdapters..
-    /// @param domain Uint256 identifier for the domain to query.
-    /// @param _adapters Array of oracle adapter addresses to query.
-    /// @param id Uint256 identifier to query.
-    /// @return hash Bytes32 hash agreed upon by the oracles for the given domain.
-    /// @notice _adapters must be in numberical order from smallest to largest and contain no duplicates.
-    /// @notice Reverts if _adapters are out of order or contain duplicates.
-    /// @notice Reverts if oracles disagree.
-    /// @notice Reverts if oracles have not yet reported the hash for the given ID.
-    /// @notice Reverts if no oracles are set for the given domain.
+    /**
+     * @dev Returns the hash unanimously agreed upon by all of the given oraclesAdapters.
+     * @param domain - Uint256 identifier for the domain to query.
+     * @param id - Uint256 identifier to query.
+     * @param _adapters - Array of oracle adapter addresses to query.
+     * @return hash - Bytes32 hash agreed upon by the oracles for the given domain.
+     * @notice _adapters must be in numerical order from smallest to largest and contain no duplicates.
+     * @notice Reverts if _adapters are out of order or contain duplicates.
+     * @notice Reverts if oracles disagree.
+     * @notice Reverts if oracles have not yet reported the hash for the given ID.
+     * @notice Reverts if no oracles are set for the given domain.
+     */
     function _getHash(
         uint256 domain,
         uint256 id,
         IOracleAdapter[] memory _adapters
     ) internal view returns (bytes32 hash) {
         (uint256 threshold, uint256 count) = getThresholdAndCount(domain);
-        if (_adapters.length == 0) revert NoAdaptersGiven(address(this));
-        if (count == 0) revert NoAdaptersEnabled(address(this), domain);
-        if (_adapters.length < threshold) revert ThresholdNotMet(address(this));
+        if (_adapters.length == 0) revert NoAdaptersGiven();
+        if (count == 0) revert NoAdaptersEnabled(domain);
+        if (_adapters.length < threshold) revert ThresholdNotMet();
         checkAdapterOrderAndValidity(domain, _adapters);
         hash = hashi.getHash(domain, id, _adapters);
     }

--- a/packages/evm/contracts/ownable/ShuSo.sol
+++ b/packages/evm/contracts/ownable/ShuSo.sol
@@ -187,7 +187,7 @@ abstract contract ShuSo is IShuSho, OwnableUpgradeable {
             bytes32 baseHash = hashes[i];
             if (baseHash == bytes32(0)) continue;
 
-            // increment num for each instance of the curent hash
+            // increment num for each instance of the current hash
             uint256 num = 0;
             for (uint j = 0; j < hashes.length; j++) {
                 if (baseHash == hashes[j]) {

--- a/packages/evm/contracts/test/MockOracleAdapter.sol
+++ b/packages/evm/contracts/test/MockOracleAdapter.sol
@@ -5,10 +5,10 @@ import { OracleAdapter } from "../adapters/OracleAdapter.sol";
 import { BlockHashOracleAdapter } from "../adapters/BlockHashOracleAdapter.sol";
 
 contract MockOracleAdapter is OracleAdapter, BlockHashOracleAdapter {
-    error LengthMismatch(address emitter);
+    error LengthMismatch();
 
     function setHashes(uint256 domain, uint256[] memory ids, bytes32[] memory hashes) external {
-        if (ids.length != hashes.length) revert LengthMismatch(address(this));
+        if (ids.length != hashes.length) revert LengthMismatch();
         for (uint256 i = 0; i < ids.length; i++) {
             _storeHash(domain, ids[i], hashes[i]);
         }

--- a/packages/evm/contracts/utils/HeaderStorage.sol
+++ b/packages/evm/contracts/utils/HeaderStorage.sol
@@ -11,7 +11,7 @@ contract HeaderStorage is IHeaderStorage {
         bytes32 blockHeader = headers[blockNumber];
         if (blockHeader == 0) {
             blockHeader = blockhash(blockNumber);
-            if (blockHeader == 0) revert HeaderOutOfRange(address(this), blockNumber);
+            if (blockHeader == 0) revert HeaderOutOfRange(blockNumber);
             headers[blockNumber] = blockHeader;
             emit HeaderStored(blockNumber, blockHeader);
         }

--- a/packages/evm/test/02_ShoyuBashi.spec.ts
+++ b/packages/evm/test/02_ShoyuBashi.spec.ts
@@ -71,7 +71,7 @@ describe("ShoyuBashi", function () {
       const { shoyuBashi, wallet } = await setup()
       await expect(shoyuBashi.setHashi(wallet.address))
         .to.emit(shoyuBashi, "HashiSet")
-        .withArgs(shoyuBashi.address, wallet.address)
+        .withArgs(wallet.address)
     })
   })
 
@@ -97,7 +97,7 @@ describe("ShoyuBashi", function () {
       const { shoyuBashi } = await setup()
       await expect(shoyuBashi.setThreshold(DOMAIN_ID, 3))
         .to.emit(shoyuBashi, "ThresholdSet")
-        .withArgs(shoyuBashi.address, DOMAIN_ID, 3)
+        .withArgs(DOMAIN_ID, 3)
     })
   })
 
@@ -155,7 +155,7 @@ describe("ShoyuBashi", function () {
       const { shoyuBashi } = await setup()
       await expect(shoyuBashi.enableOracleAdapters(DOMAIN_ID, [ADDRESS_TWO, ADDRESS_THREE]))
         .to.emit(shoyuBashi, "OracleAdaptersEnabled")
-        .withArgs(shoyuBashi.address, DOMAIN_ID, [ADDRESS_TWO, ADDRESS_THREE])
+        .withArgs(DOMAIN_ID, [ADDRESS_TWO, ADDRESS_THREE])
     })
   })
 
@@ -217,7 +217,7 @@ describe("ShoyuBashi", function () {
       await shoyuBashi.enableOracleAdapters(DOMAIN_ID, [ADDRESS_TWO, ADDRESS_THREE])
       await expect(shoyuBashi.disableOracleAdapters(DOMAIN_ID, [ADDRESS_THREE, ADDRESS_TWO]))
         .to.emit(shoyuBashi, "OracleAdaptersDisabled")
-        .withArgs(shoyuBashi.address, DOMAIN_ID, [ADDRESS_THREE, ADDRESS_TWO])
+        .withArgs(DOMAIN_ID, [ADDRESS_THREE, ADDRESS_TWO])
     })
   })
 

--- a/packages/evm/test/02_ShoyuBashi.spec.ts
+++ b/packages/evm/test/02_ShoyuBashi.spec.ts
@@ -69,9 +69,7 @@ describe("ShoyuBashi", function () {
     })
     it("Emits HashiSet() event", async function () {
       const { shoyuBashi, wallet } = await setup()
-      await expect(shoyuBashi.setHashi(wallet.address))
-        .to.emit(shoyuBashi, "HashiSet")
-        .withArgs(wallet.address)
+      await expect(shoyuBashi.setHashi(wallet.address)).to.emit(shoyuBashi, "HashiSet").withArgs(wallet.address)
     })
   })
 
@@ -95,9 +93,7 @@ describe("ShoyuBashi", function () {
     })
     it("Emits HashiSet() event", async function () {
       const { shoyuBashi } = await setup()
-      await expect(shoyuBashi.setThreshold(DOMAIN_ID, 3))
-        .to.emit(shoyuBashi, "ThresholdSet")
-        .withArgs(DOMAIN_ID, 3)
+      await expect(shoyuBashi.setThreshold(DOMAIN_ID, 3)).to.emit(shoyuBashi, "ThresholdSet").withArgs(DOMAIN_ID, 3)
     })
   })
 

--- a/packages/evm/test/03_GiriGiriBashi.spec.ts
+++ b/packages/evm/test/03_GiriGiriBashi.spec.ts
@@ -107,7 +107,7 @@ describe("GiriGiriBashi", function () {
     it("Emits HashiSet() event", async function () {
       const { giriGiriBashi, hashi } = await setup()
       const tx = await giriGiriBashi.deployTransaction
-      await expect(tx).to.emit(giriGiriBashi, "HashiSet").withArgs(giriGiriBashi.address, hashi.address)
+      await expect(tx).to.emit(giriGiriBashi, "HashiSet").withArgs(hashi.address)
     })
   })
 
@@ -129,7 +129,7 @@ describe("GiriGiriBashi", function () {
       const { giriGiriBashi } = await setup()
       await expect(giriGiriBashi.setThreshold(DOMAIN_ID, 3))
         .to.emit(giriGiriBashi, "ThresholdSet")
-        .withArgs(giriGiriBashi.address, DOMAIN_ID, 3)
+        .withArgs(DOMAIN_ID, 3)
     })
   })
 
@@ -152,7 +152,6 @@ describe("GiriGiriBashi", function () {
       const { giriGiriBashi, settings } = await setup()
       await expect(giriGiriBashi.enableOracleAdapters(DOMAIN_ID, [ADDRESS_TWO], [settings, settings]))
         .to.be.revertedWithCustomError(giriGiriBashi, "UnequalArrayLengths")
-        .withArgs(giriGiriBashi.address)
     })
     it("Enables the given oracles", async function () {
       const { giriGiriBashi, settings } = await setup()
@@ -183,7 +182,7 @@ describe("GiriGiriBashi", function () {
       const { giriGiriBashi, settings } = await setup()
       await expect(giriGiriBashi.enableOracleAdapters(DOMAIN_ID, [ADDRESS_TWO, ADDRESS_THREE], [settings, settings]))
         .to.emit(giriGiriBashi, "OracleAdaptersEnabled")
-        .withArgs(giriGiriBashi.address, DOMAIN_ID, [ADDRESS_TWO, ADDRESS_THREE])
+        .withArgs(DOMAIN_ID, [ADDRESS_TWO, ADDRESS_THREE])
     })
   })
 
@@ -192,7 +191,6 @@ describe("GiriGiriBashi", function () {
       const { giriGiriBashi } = await setup()
       await expect(giriGiriBashi.disableOracleAdapters(DOMAIN_ID, [ADDRESS_TWO]))
         .to.be.revertedWithCustomError(giriGiriBashi, "NoConfidenceRequired")
-        .withArgs(giriGiriBashi.address)
     })
     it("Disables the given oracles", async function () {
       const { giriGiriBashi, settings } = await setup()
@@ -261,7 +259,7 @@ describe("GiriGiriBashi", function () {
       const { giriGiriBashi, mockOracleAdapter } = await setup()
       await expect(giriGiriBashi.challengeOracleAdapter(DOMAIN_ID, 1, mockOracleAdapter.address))
         .to.be.revertedWithCustomError(giriGiriBashi, "AdapterNotEnabled")
-        .withArgs(giriGiriBashi.address, mockOracleAdapter.address)
+        .withArgs(mockOracleAdapter.address)
     })
     it("Reverts if value is less than minimum bond", async function () {
       const { giriGiriBashi, mockOracleAdapter, secondMockOracleAdapter, settings } = await setup()
@@ -272,7 +270,7 @@ describe("GiriGiriBashi", function () {
       )
       await expect(giriGiriBashi.challengeOracleAdapter(DOMAIN_ID, 1, mockOracleAdapter.address))
         .to.be.revertedWithCustomError(giriGiriBashi, "NotEnoughtValue")
-        .withArgs(giriGiriBashi.address, mockOracleAdapter.address, 0)
+        .withArgs(mockOracleAdapter.address, 0)
     })
     it("Reverts if adapter is already quarantined", async function () {
       const { giriGiriBashi, mockOracleAdapter, secondMockOracleAdapter, settings } = await setup()
@@ -300,7 +298,7 @@ describe("GiriGiriBashi", function () {
         }),
       )
         .to.be.revertedWithCustomError(giriGiriBashi, "AlreadyQuarantined")
-        .withArgs(giriGiriBashi.address, mockOracleAdapter.address)
+        .withArgs(mockOracleAdapter.address)
     })
     it("Reverts if duplicate challenge exists", async function () {
       const { giriGiriBashi, mockOracleAdapter, secondMockOracleAdapter, settings } = await setup()
@@ -336,7 +334,7 @@ describe("GiriGiriBashi", function () {
         giriGiriBashi.callStatic.challengeOracleAdapter(DOMAIN_ID, 0, mockOracleAdapter.address, { value: BOND }),
       )
         .to.be.revertedWithCustomError(giriGiriBashi, "OutOfRange")
-        .withArgs(giriGiriBashi.address, mockOracleAdapter.address, 0)
+        .withArgs(mockOracleAdapter.address, 0)
 
       // revert on block too far in the future
       const outOfRangeBlock = head + CHALLENGE_RANGE + 1
@@ -346,7 +344,7 @@ describe("GiriGiriBashi", function () {
         }),
       )
         .to.be.revertedWithCustomError(giriGiriBashi, "OutOfRange")
-        .withArgs(giriGiriBashi.address, mockOracleAdapter.address, outOfRangeBlock)
+        .withArgs(mockOracleAdapter.address, outOfRangeBlock)
 
       // revert on block too deep for adapter
       const tooDeepBlock = 1
@@ -356,7 +354,7 @@ describe("GiriGiriBashi", function () {
         }),
       )
         .to.be.revertedWithCustomError(giriGiriBashi, "OutOfRange")
-        .withArgs(giriGiriBashi.address, mockOracleAdapter.address, tooDeepBlock)
+        .withArgs(mockOracleAdapter.address, tooDeepBlock)
 
       // make sure it can actually be successful / doesn't always revert
       expect(
@@ -493,7 +491,7 @@ describe("GiriGiriBashi", function () {
         ]),
       )
         .to.be.revertedWithCustomError(hashi, "OraclesDisagree")
-        .withArgs(giriGiriBashi.address, mockOracleAdapter.address, secondMockOracleAdapter.address)
+        .withArgs(mockOracleAdapter.address, secondMockOracleAdapter.address)
     })
     it("Keeps bond if canonical hash matches hash reported by challenged adapter", async function () {
       const { giriGiriBashi, mockOracleAdapter, secondMockOracleAdapter, thirdMockOracleAdapter, settings } =
@@ -600,7 +598,6 @@ describe("GiriGiriBashi", function () {
       )
         .to.emit(giriGiriBashi, "ChallengeResolved")
         .withArgs(
-          giriGiriBashi.address,
           challengeId,
           DOMAIN_ID,
           challengeBlock,
@@ -624,7 +621,7 @@ describe("GiriGiriBashi", function () {
       await giriGiriBashi.enableOracleAdapters(DOMAIN_ID, adapters, [settings, settings, settings])
       await expect(giriGiriBashi.callStatic.declareNoConfidence(DOMAIN_ID, 20, [mockOracleAdapter.address]))
         .to.be.revertedWithCustomError(giriGiriBashi, "CannotProveNoConfidence")
-        .withArgs(giriGiriBashi.address, DOMAIN_ID, 20, [mockOracleAdapter.address])
+        .withArgs(DOMAIN_ID, 20, [mockOracleAdapter.address])
     })
     it("Reverts if any of the provided adapters agree", async function () {
       const { giriGiriBashi, mockOracleAdapter, secondMockOracleAdapter, thirdMockOracleAdapter, settings } =
@@ -638,7 +635,7 @@ describe("GiriGiriBashi", function () {
       await giriGiriBashi.enableOracleAdapters(DOMAIN_ID, adapters, [settings, settings, settings])
       await expect(giriGiriBashi.callStatic.declareNoConfidence(DOMAIN_ID, 22, adapters))
         .to.be.revertedWithCustomError(giriGiriBashi, "AdaptersAgreed")
-        .withArgs(giriGiriBashi.address, adaptersThatAgree[0], adaptersThatAgree[1])
+        .withArgs(adaptersThatAgree[0], adaptersThatAgree[1])
     })
     it("Clears state for domain", async function () {
       const { giriGiriBashi, mockOracleAdapter, secondMockOracleAdapter, thirdMockOracleAdapter, settings } =
@@ -666,7 +663,7 @@ describe("GiriGiriBashi", function () {
       await giriGiriBashi.enableOracleAdapters(DOMAIN_ID, adapters, [settings, settings, settings])
       await expect(giriGiriBashi.declareNoConfidence(DOMAIN_ID, 20, adapters))
         .to.emit(giriGiriBashi, "NoConfidenceDeclareed")
-        .withArgs(giriGiriBashi.address, DOMAIN_ID)
+        .withArgs(DOMAIN_ID)
     })
   })
 
@@ -687,7 +684,7 @@ describe("GiriGiriBashi", function () {
       const { giriGiriBashi } = await setup()
       await expect(giriGiriBashi.callStatic.setChallengeRange(DOMAIN_ID, CHALLENGE_RANGE))
         .to.be.revertedWithCustomError(giriGiriBashi, "ChallengeRangeAlreadySet")
-        .withArgs(giriGiriBashi.address, DOMAIN_ID)
+        .withArgs(DOMAIN_ID)
     })
     it("Sets challenge range for given domain", async function () {
       const { giriGiriBashi } = await setup()
@@ -699,7 +696,7 @@ describe("GiriGiriBashi", function () {
       const { giriGiriBashi } = await setup()
       await expect(giriGiriBashi.setChallengeRange(2, CHALLENGE_RANGE))
         .to.emit(giriGiriBashi, "ChallegenRangeUpdated")
-        .withArgs(giriGiriBashi.address, 2, CHALLENGE_RANGE)
+        .withArgs(2, CHALLENGE_RANGE)
     })
   })
 


### PR DESCRIPTION
This pr includes the following changes:
- Fixed `ShuSo._getThresholdHash` for when the `threshold = 1`. 
- Created `IShuSho`, `IShoyuBashi` and `IGiriGiriBashi`.
- Removed `address emitter` within events and custom error to save gas