### PR TITLE
Update hyperbridge adapter to v1.0.0

### DIFF
--- a/packages/evm/contracts/adapters/Hyperbridge/HyperbridgeAdapter.sol
+++ b/packages/evm/contracts/adapters/Hyperbridge/HyperbridgeAdapter.sol
@@ -11,7 +11,7 @@ contract HyperbridgeAdapter is BlockHashAdapter, Ownable, BaseIsmpModule {
     mapping(bytes32 => uint256) public chainIds;
 
     // @dev The address of the IsmpHost on the current chain
-    address public _host;
+    address private _host;
 
     constructor(address ismpHost) {
         _host = ismpHost;

--- a/packages/evm/contracts/adapters/Hyperbridge/HyperbridgeAdapter.sol
+++ b/packages/evm/contracts/adapters/Hyperbridge/HyperbridgeAdapter.sol
@@ -10,6 +10,17 @@ contract HyperbridgeAdapter is BlockHashAdapter, Ownable, BaseIsmpModule {
     mapping(bytes32 => bytes32) public enabledReporters;
     mapping(bytes32 => uint256) public chainIds;
 
+    // @dev The address of the IsmpHost on the current chain
+    address public _host;
+
+    constructor(address ismpHost) {
+        _host = ismpHost;
+    }
+
+    function host() public view override returns (address) {
+        return _host;
+    }
+
     error UnauthorizedRequest();
 
     event ReporterSet(uint256 indexed chainId, address indexed reporter);

--- a/packages/evm/contracts/adapters/Hyperbridge/HyperbridgeReporter.sol
+++ b/packages/evm/contracts/adapters/Hyperbridge/HyperbridgeReporter.sol
@@ -11,11 +11,18 @@ import { Reporter } from "../Reporter.sol";
 contract HyperbridgeReporter is Reporter, Ownable, BaseIsmpModule {
     string public constant PROVIDER = "hyperbridge";
 
-    constructor(address headerStorage, address yaho) Reporter(headerStorage, yaho) {
-        address host = host();
-        address feeToken = IDispatcher(host).feeToken();
+    // @dev The address of the IsmpHost on the current chain
+    address public _host;
+
+    constructor(address headerStorage, address yaho, address ismpHost) Reporter(headerStorage, yaho) {
+        _host = ismpHost;
+        address feeToken = IDispatcher(ismpHost).feeToken();
         // approve the host to spend infinitely
-        IERC20(feeToken).approve(host, type(uint256).max);
+        IERC20(feeToken).approve(ismpHost, type(uint256).max);
+    }
+
+    function host() public view override returns (address) {
+        return _host;
     }
 
     function _dispatch(

--- a/packages/evm/contracts/adapters/Hyperbridge/HyperbridgeReporter.sol
+++ b/packages/evm/contracts/adapters/Hyperbridge/HyperbridgeReporter.sol
@@ -12,7 +12,7 @@ contract HyperbridgeReporter is Reporter, Ownable, BaseIsmpModule {
     string public constant PROVIDER = "hyperbridge";
 
     // @dev The address of the IsmpHost on the current chain
-    address public _host;
+    address private _host;
 
     constructor(address headerStorage, address yaho, address ismpHost) Reporter(headerStorage, yaho) {
         _host = ismpHost;

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -87,7 +87,7 @@
     "@layerzerolabs/lz-evm-oapp-v2": "^2.3.29",
     "@layerzerolabs/lz-evm-protocol-v2": "^2.3.29",
     "@openzeppelin/contracts-upgradeable": "4.8.1",
-    "@polytope-labs/ismp-solidity": "^0.7.4",
+    "@polytope-labs/ismp-solidity": "^1.0.0",
     "@polytope-labs/solidity-merkle-trees": "0.3.2",
     "@routerprotocol/evm-gateway-contracts": "1.1.13",
     "solidity-bytes-utils": "^0.8.2",

--- a/packages/evm/tasks/deploy/adapters/hyperbridge.ts
+++ b/packages/evm/tasks/deploy/adapters/hyperbridge.ts
@@ -10,13 +10,14 @@ import { verify } from "../index"
 
 task("deploy:HyperbridgeAdapter")
   .addFlag("verify", "whether to verify the contract on Etherscan")
+  .addParam("ismpHost", "The address of the IsmpHost on the current chain")
   .setAction(async function (taskArguments: TaskArguments, hre) {
     console.log("Deploying HyperbridgeAdapter...")
     const signers: SignerWithAddress[] = await hre.ethers.getSigners()
     const HyperbridgeAdapterFactory: HyperbridgeAdapter__factory = <HyperbridgeAdapter__factory>(
       await hre.ethers.getContractFactory("HyperbridgeAdapter")
     )
-    const constructorArguments = [] as const
+    const constructorArguments = [taskArguments.ismpHost] as const
     const HyperbridgeAdapter: HyperbridgeAdapter = <HyperbridgeAdapter>(
       await HyperbridgeAdapterFactory.connect(signers[0]).deploy(...constructorArguments)
     )
@@ -28,6 +29,7 @@ task("deploy:HyperbridgeAdapter")
 task("deploy:HyperbridgeReporter")
   .addParam("headerStorage", "address of the header storage contract")
   .addParam("yaho", "address of the Yaho contract")
+  .addParam("ismpHost", "The address of the IsmpHost on the current chain")
   .addFlag("verify", "whether to verify the contract on Etherscan")
   .setAction(async function (taskArguments: TaskArguments, hre) {
     console.log("Deploying HyperbridgeReporter...")
@@ -35,7 +37,7 @@ task("deploy:HyperbridgeReporter")
     const HyperbridgeReporterFactory: HyperbridgeReporter__factory = <HyperbridgeReporter__factory>(
       await hre.ethers.getContractFactory("HyperbridgeReporter")
     )
-    const constructorArguments = [taskArguments.headerStorage, taskArguments.yaho] as const
+    const constructorArguments = [taskArguments.headerStorage, taskArguments.yaho, taskArguments.ismpHost] as const
     const HyperbridgeReporter: HyperbridgeReporter = <HyperbridgeReporter>(
       await HyperbridgeReporterFactory.connect(signers[0]).deploy(...constructorArguments)
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1217,10 +1217,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.3.tgz#ff6ee919fc2a1abaf72b22814bfb72ed129ec137"
   integrity sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g==
 
-"@polytope-labs/ismp-solidity@^0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@polytope-labs/ismp-solidity/-/ismp-solidity-0.7.4.tgz#00a9e02f2eb0cdbb444fb3f244dc8199c5bfb685"
-  integrity sha512-NLthu+D+ycLwMkSgdURpzfotKs9NtFuI/TKcNm+8XH8FF74B26o8BOJMtvE2TD2TPOxu9rcs54u2p5HNaHoU2w==
+"@polytope-labs/ismp-solidity@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@polytope-labs/ismp-solidity/-/ismp-solidity-1.0.0.tgz#0af23618da591aefca6808881ce8b55815f3b90c"
+  integrity sha512-0jpCueJFv98R/8w6wk9ufMRXb5dYjN4RSfZDhRphnKpVgD7Zmwb92RdqIjTesbFwxjiVpWkTzvhppQsZj6jdpg==
   dependencies:
     "@polytope-labs/solidity-merkle-trees" "^0.3.3"
     openzeppelin-solidity "^4.8.1"


### PR DESCRIPTION
Hyperbridge has been deployed to mainnet. We've updated the SDK to v1.0.0 and removed the hardcoded host addresses.