### PR TITLE
fix(evm): block_roots_gindex in merkle.sol

### DIFF
--- a/packages/evm/contracts/adapters/Spectre/lib/Merkle.sol
+++ b/packages/evm/contracts/adapters/Spectre/lib/Merkle.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 library Merkle {
     uint256 internal constant SLOTS_PER_HISTORICAL_ROOT = 8192;
     // BeaconState -> BlockRoots
-    uint256 internal constant BLOCK_ROOTS_GINDEX = 37;
+    uint256 internal constant BLOCK_ROOTS_GINDEX = 69;
     // BeaconBlock -> BeaconState
     uint256 internal constant STATE_ROOT_GINDEX = 11;
     // BeaconBlock -> BeaconBody -> ExecutionPayload -> ReceiptsRoot


### PR DESCRIPTION
Fix the BLOCK_ROOTS_GINDEX in Merkle.sol post Pectra.