### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v5"
 
       - name: "Install Node.js"
         uses: "actions/setup-node@v3"


### PR DESCRIPTION
Updates actions/checkout@v3 to actions/checkout@v5 across CI workflows.
Upgrade to actions/checkout@v5 for improved performance and stability.

**Reference:**

Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0